### PR TITLE
Fix small typo in docs for rule NoProtectedElementInFinalClassRule

### DIFF
--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -3081,7 +3081,7 @@ Instead of protected element in final class use private element or contract meth
 ```php
 final class SomeClass
 {
-    private function run()
+    protected function run()
     {
     }
 }


### PR DESCRIPTION
`Before` and `after` were the same. In the `before` section there should be `protected` instead of `private`.