### PR TITLE
Make output more visible/clear

### DIFF
--- a/src/Rules/Explicit/NoMixedMethodCallerRule.php
+++ b/src/Rules/Explicit/NoMixedMethodCallerRule.php
@@ -20,7 +20,7 @@ final class NoMixedMethodCallerRule extends AbstractSymplifyRule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Anonymous variables in a method call can lead to false dead methods. Make sure the variable type is known';
+    public const ERROR_MESSAGE = 'Anonymous variables in a method call can lead to false dead methods. Make sure the variable type is known in method name `%s()`';
 
     /**
      * @return array<class-string<Node>>
@@ -41,7 +41,7 @@ final class NoMixedMethodCallerRule extends AbstractSymplifyRule
             return [];
         }
 
-        return [self::ERROR_MESSAGE];
+        return [sprintf(self::ERROR_MESSAGE, ...)];
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
I tried out your rule, but all I get is

  451    Anonymous variables in a method call can lead to false dead methods. Make sure the variable type is
         known
  452    Anonymous variables in a method call can lead to false dead methods. Make sure the variable type is
         known
  475    Anonymous variables in a property fetch can lead to false dead property. Make sure the variable type is
         known
  495    Anonymous variables in a property fetch can lead to false dead property. Make sure the variable type is
         known
  495    Anonymous variables in a property fetch can lead to false dead property. Make sure the variable type is
         known
         
With tons of classes I would like to see the method names or some context along with it to help determine the groups to work on this.

What do you think?
How can we find the method name here to inject into the message?