### PR TITLE
Support Contracts (plural form) to be nice to Laravel

### DIFF
--- a/src/Rules/CheckRequiredInterfaceInContractNamespaceRule.php
+++ b/src/Rules/CheckRequiredInterfaceInContractNamespaceRule.php
@@ -22,13 +22,13 @@ final class CheckRequiredInterfaceInContractNamespaceRule implements Rule, Docum
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Interface must be located in "Contract" namespace';
+    public const ERROR_MESSAGE = 'Interface must be located in "Contract" or "Contracts" namespace';
 
     /**
      * @var string
-     * @see https://regex101.com/r/kmrIG1/1
+     * @see https://regex101.com/r/kmrIG1/2
      */
-    private const A_CONTRACT_NAMESPACE_REGEX = '#\bContract\b#';
+    private const A_CONTRACT_NAMESPACE_REGEX = '#\bContracts?\b#';
 
     /**
      * @return class-string<Node>
@@ -70,6 +70,12 @@ CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 namespace App\Contract\Repository;
+
+interface ProductRepositoryInterface
+{
+}
+
+namespace App\Contracts\Repository;
 
 interface ProductRepositoryInterface
 {

--- a/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/CheckRequiredInterfaceInContractNamespaceRuleTest.php
+++ b/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/CheckRequiredInterfaceInContractNamespaceRuleTest.php
@@ -26,6 +26,7 @@ final class CheckRequiredInterfaceInContractNamespaceRuleTest extends RuleTestCa
     public function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/Contract/SkipInterfaceInContract.php', []];
+        yield [__DIR__ . '/Fixture/Illuminate/Contracts/View/View.php', []];
         yield [
             __DIR__ . '/Fixture/AnInterfaceNotInContract.php',
             [[CheckRequiredInterfaceInContractNamespaceRule::ERROR_MESSAGE, 7]], ];

--- a/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/Fixture/Illuminate/Contracts/View/View.php
+++ b/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/Fixture/Illuminate/Contracts/View/View.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\View;
+
+interface View
+{
+}


### PR DESCRIPTION
Laravel use the wording Contract**s** instead of just Contract for their interfaces.
I really like the idea behind this rule but it would also be nice to support the plural form.

Keep the spirit of the rule while making it a tiny bit less strict. 
Similar to my previous PR on the Tests prefix,
I also updated the URL of the regex: https://regex101.com/r/kmrIG1/2
