### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "phpstan-extension",
     "description": "Set of Symplify rules for PHPStan",
     "license": "MIT",
+    "keywords": ["dev"],
     "require": {
         "php": ">=8.1",
         "nikic/php-parser": "^4.15.3",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency