### PR TITLE
Improve CheckSprintfMatchingTypesRule error reporting

### DIFF
--- a/src/Rules/Missing/CheckSprintfMatchingTypesRule.php
+++ b/src/Rules/Missing/CheckSprintfMatchingTypesRule.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
 use Symplify\PHPStanRules\NodeAnalyzer\SprintfSpecifierTypeResolver;
 use Symplify\PHPStanRules\TypeAnalyzer\MatchingTypeAnalyzer;
 use Symplify\PHPStanRules\TypeResolver\ArgTypeResolver;
@@ -29,7 +31,7 @@ final class CheckSprintfMatchingTypesRule implements Rule, DocumentedRuleInterfa
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'sprintf() call mask types does not match provided arguments types';
+    public const ERROR_MESSAGE = 'sprintf() call mask type at index [%d] expects type "%s", but "%s" given';
 
     /**
      * @var string
@@ -83,6 +85,11 @@ final class CheckSprintfMatchingTypesRule implements Rule, DocumentedRuleInterfa
             return [];
         }
 
+        $errors = [];
+
+        /**
+         * @var int $key
+         */
         foreach ($argTypes as $key => $argType) {
             $expectedTypes = $expectedTypesByPosition[$key];
 
@@ -90,10 +97,14 @@ final class CheckSprintfMatchingTypesRule implements Rule, DocumentedRuleInterfa
                 continue;
             }
 
-            return [self::ERROR_MESSAGE];
+            $expectedTypeDescription = implode('|', array_map(function (Type $type): string {
+                return $type->describe(VerbosityLevel::typeOnly());
+            }, $expectedTypes));
+
+            $errors[] = sprintf(self::ERROR_MESSAGE, $key, $expectedTypeDescription, $argType->describe(VerbosityLevel::typeOnly()));
         }
 
-        return [];
+        return $errors;
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/tests/Rules/Missing/CheckSprintfMatchingTypesRule/CheckSprintfMatchingTypesRuleTest.php
+++ b/tests/Rules/Missing/CheckSprintfMatchingTypesRule/CheckSprintfMatchingTypesRuleTest.php
@@ -23,7 +23,10 @@ final class CheckSprintfMatchingTypesRuleTest extends RuleTestCase
 
     public static function provideData(): Iterator
     {
-        yield [__DIR__ . '/Fixture/MissMatchSprintf.php', [[CheckSprintfMatchingTypesRule::ERROR_MESSAGE, 11]]];
+        yield [__DIR__ . '/Fixture/MissMatchSprintf.php', [
+            ['sprintf() call mask type at index [0] expects type "string", but "int" given', 11],
+            ['sprintf() call mask type at index [1] expects type "int|float", but "string" given', 11],
+        ]];
 
         yield [__DIR__ . '/Fixture/SkipCorrectSprintf.php', []];
         yield [__DIR__ . '/Fixture/SkipCorrectForeachKey.php', []];


### PR DESCRIPTION
The error reproting for mismatching types in sprintf calls was only pretty basic and made it quite hard to figure out exactly what was wrong.

Now you get a error message specifing the index and the types that are expected and actually were passed, making it a lot easier to actually fix those reported errors.