### PR TITLE
Fix static calls on variables in RequireThisOnParentMethodCallRule

### DIFF
--- a/src/Rules/RequireThisOnParentMethodCallRule.php
+++ b/src/Rules/RequireThisOnParentMethodCallRule.php
@@ -6,6 +6,7 @@ namespace Symplify\PHPStanRules\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
@@ -62,6 +63,10 @@ final class RequireThisOnParentMethodCallRule implements Rule, DocumentedRuleInt
             $staticCalls = $this->nodeFinder->findInstanceOf($classMethod, StaticCall::class);
 
             foreach ($staticCalls as $staticCall) {
+                if ($staticCall->class instanceof Variable) {
+                    continue;
+                }
+
                 if ($this->isParentCallInSameClassMethod($staticCall, $classMethod)) {
                     continue;
                 }

--- a/tests/Rules/RequireThisOnParentMethodCallRule/Fixture/SkipDynamicStaticCallsOnClassStrings.php
+++ b/tests/Rules/RequireThisOnParentMethodCallRule/Fixture/SkipDynamicStaticCallsOnClassStrings.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireThisOnParentMethodCallRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipDynamicStaticCallsOnClassStrings extends ParentClass
+{
+    public function foo()
+    {
+        $testClass = TestCase::class;
+        $testClass::isEmpty();
+    }
+}

--- a/tests/Rules/RequireThisOnParentMethodCallRule/RequireThisOnParentMethodCallRuleTest.php
+++ b/tests/Rules/RequireThisOnParentMethodCallRule/RequireThisOnParentMethodCallRuleTest.php
@@ -25,6 +25,7 @@ final class RequireThisOnParentMethodCallRuleTest extends RuleTestCase
     {
         yield [__DIR__ . '/Fixture/SkipCallParentMethodStaticallySameMethod.php', []];
         yield [__DIR__ . '/Fixture/SkipCallParentMethodStaticallyWhenMethodOverriden.php', []];
+        yield [__DIR__ . '/Fixture/SkipDynamicStaticCallsOnClassStrings.php', []];
 
         yield [
             __DIR__ . '/Fixture/CallParentMethodStatically.php',


### PR DESCRIPTION
The `RequireThisOnParentMethodCallRule` was overly strict and reported all static calls on variables as well.

In most cases you should never make a static call on a variable (the only valid case would be making a static call on a variable that contains a class string), but that is not the scope of this rule.

Now the `RequireThisOnParentMethodCallRule` skips all static calls on variables