### PR TITLE
nette/utils 4.0

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "nikic/php-parser": "^4.15.2",
-        "nette/utils": "^3.2",
+        "nette/utils": "^3.2 || ^4.0",
         "phpstan/phpdoc-parser": "^1.15.0",
         "phpstan/phpstan": "^1.9.11",
         "webmozart/assert": "^1.10"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.1",
         "nikic/php-parser": "^4.15.3",
-        "nette/utils": "^3.2.9",
+        "nette/utils": "^3.2.9 || ^4.0",
         "phpstan/phpdoc-parser": "^1.16.1",
         "webmozart/assert": "^1.11",
         "symplify/rule-doc-generator-contracts": "^11.1.26"


### PR DESCRIPTION
Same thing as earlier for tomasvotruba/type-coverage. Let's check first if nothing fails with 4.0 and allow both if it's fine.