### PR TITLE
Improvement: Make ForbiddenThisArgumentRule configurable

### DIFF
--- a/config/symplify-rules.neon
+++ b/config/symplify-rules.neon
@@ -30,3 +30,10 @@ services:
                 PhpParser\Node:
                     getAttribute: [0]
                     setAttribute: [0]
+
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenThisArgumentRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            allowedCallerClasses:
+                - Symplify\PackageBuilder\Reflection\PrivatesCaller

--- a/src/Rules/ForbiddenThisArgumentRule.php
+++ b/src/Rules/ForbiddenThisArgumentRule.php
@@ -102,21 +102,17 @@ CODE_SAMPLE
         return $classReflection->isSubclassOf(Kernel::class);
     }
 
-    private function shouldSkip(MethodCall | FuncCall | StaticCall $node, Scope $scope): bool
+    private function shouldSkip(MethodCall | StaticCall $node, Scope $scope): bool
     {
         if ($node instanceof MethodCall) {
             return $this->containsTypeAnalyser->containsExprTypes($node->var, $scope, $this->allowedCallerClasses);
         }
 
-        if ($node instanceof StaticCall) {
-            $class = $node->class;
-            if ($class instanceof Expr) {
-                return $this->containsTypeAnalyser->containsExprTypes($class, $scope, $this->allowedCallerClasses);
-            }
-
-            return in_array($class->toString(), $this->allowedCallerClasses, true);
+        $class = $node->class;
+        if ($class instanceof Expr) {
+            return $this->containsTypeAnalyser->containsExprTypes($class, $scope, $this->allowedCallerClasses);
         }
 
-        return false;
+        return in_array($class->toString(), $this->allowedCallerClasses, true);
     }
 }

--- a/tests/Rules/ForbiddenThisArgumentRule/Fixture/SkipAllowedStaticCall.php
+++ b/tests/Rules/ForbiddenThisArgumentRule/Fixture/SkipAllowedStaticCall.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenThisArgumentRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenThisArgumentRule\Source\AllowedStaticService;
+
+final class SkipAllowedStaticCall
+{
+    public function run()
+    {
+        AllowedStaticService::someMethod($this);
+    }
+}

--- a/tests/Rules/ForbiddenThisArgumentRule/ForbiddenThisArgumentRuleTest.php
+++ b/tests/Rules/ForbiddenThisArgumentRule/ForbiddenThisArgumentRuleTest.php
@@ -29,6 +29,7 @@ final class ForbiddenThisArgumentRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipNotVariable.php', []];
         yield [__DIR__ . '/Fixture/SkipNotThis.php', []];
         yield [__DIR__ . '/Fixture/SkipExtendsKernel.php', []];
+        yield [__DIR__ . '/Fixture/SkipAllowedStaticCall.php', []];
 
         yield [__DIR__ . '/Fixture/StaticCall.php', [[ForbiddenThisArgumentRule::ERROR_MESSAGE, 13]]];
         yield [__DIR__ . '/Fixture/ThisArgument.php', [[ForbiddenThisArgumentRule::ERROR_MESSAGE, 11]]];

--- a/tests/Rules/ForbiddenThisArgumentRule/Source/AllowedStaticService.php
+++ b/tests/Rules/ForbiddenThisArgumentRule/Source/AllowedStaticService.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenThisArgumentRule\Source;
+
+final class AllowedStaticService
+{
+    public static function someMethod($value)
+    {
+    }
+}

--- a/tests/Rules/ForbiddenThisArgumentRule/config/configured_rule.neon
+++ b/tests/Rules/ForbiddenThisArgumentRule/config/configured_rule.neon
@@ -1,5 +1,11 @@
 includes:
     - ../../../config/included_services.neon
 
-rules:
-    - Symplify\PHPStanRules\Rules\ForbiddenThisArgumentRule
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenThisArgumentRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            allowedCallerClasses:
+                - Symplify\PackageBuilder\Reflection\PrivatesCaller
+                - Symplify\PHPStanRules\Tests\Rules\ForbiddenThisArgumentRule\Source\AllowedStaticService


### PR DESCRIPTION
There are some cases where it makes sense to allow this as arguments, the exception needed for symplify already proves the point, another use case i encountered was using symfonys `ValidatorInterface` to validate data structs, so for me it makes sense to have that rule configurable

For now by default there is no exception configured, so the rule can stay in the `static-rules` rule set, only for the `symplify-rules` rule set do we add the exception for the symplify class that was hard coded before.

In addition now calls to static methods can be allowed by config as well.