### PR TITLE
Ignore abstract base-classes in CheckTypehintCallerTypeRule  

### DIFF
--- a/src/Rules/CheckTypehintCallerTypeRule.php
+++ b/src/Rules/CheckTypehintCallerTypeRule.php
@@ -187,6 +187,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $classReflection = $objectType->getClassReflection();
+        if ($classReflection !== null && $classReflection->isAbstract()) {
+            return null;
+        }
+
         // handle weird type substration cases
         $paramTypeAsString = $objectType->describe(VerbosityLevel::typeOnly());
         $argTypeAsString = $argType->describe(VerbosityLevel::typeOnly());

--- a/tests/Rules/CheckTypehintCallerTypeRule/CheckTypehintCallerTypeRuleTest.php
+++ b/tests/Rules/CheckTypehintCallerTypeRule/CheckTypehintCallerTypeRuleTest.php
@@ -49,6 +49,7 @@ final class CheckTypehintCallerTypeRuleTest extends RuleTestCase
         $paramErrorMessage = sprintf(CheckTypehintCallerTypeRule::ERROR_MESSAGE, 2, Param::class);
         yield [__DIR__ . '/Fixture/DoubleShot.php', [[$argErrorMessage, 15], [$paramErrorMessage, 15]]];
         yield [__DIR__ . '/Fixture/SkipGenericType.php', []];
+        yield [__DIR__ . '/Fixture/SkipAbstractBase.php', []];
     }
 
     /**

--- a/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipAbstractBase.php
+++ b/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipAbstractBase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SkipAbstractBase;
+
+use Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Source\ConceptBase;
+use Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Source\ConceptImpl1;
+
+class MyService {
+    public function run(ConceptImpl1 $arg)
+    {
+        $this->isCheck($arg);
+    }
+    private function isCheck(ConceptBase $arg)
+    {
+    }
+}

--- a/tests/Rules/CheckTypehintCallerTypeRule/Source/ConceptBase.php
+++ b/tests/Rules/CheckTypehintCallerTypeRule/Source/ConceptBase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Source;
+
+
+abstract class ConceptBase
+{
+}

--- a/tests/Rules/CheckTypehintCallerTypeRule/Source/ConceptImpl1.php
+++ b/tests/Rules/CheckTypehintCallerTypeRule/Source/ConceptImpl1.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Source;
+
+class ConceptImpl1 extends ConceptBase
+{
+}


### PR DESCRIPTION
reproduces https://github.com/symplify/phpstan-rules/issues/24