### PR TITLE
Ignore class-const in NoRelativeFilePathRule

### DIFF
--- a/src/NodeVisitor/StringOutsideConcatFindingNodeVisitor.php
+++ b/src/NodeVisitor/StringOutsideConcatFindingNodeVisitor.php
@@ -49,6 +49,10 @@ final class StringOutsideConcatFindingNodeVisitor extends NodeVisitorAbstract
             return NodeTraverser::DONT_TRAVERSE_CHILDREN;
         }
 
+        if ($node instanceof Node\Stmt\ClassConst) {
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
         if (! $node instanceof String_) {
             return null;
         }

--- a/tests/Rules/Explicit/NoRelativeFilePathRule/Fixture/SkipClassConsts.php
+++ b/tests/Rules/Explicit/NoRelativeFilePathRule/Fixture/SkipClassConsts.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoRelativeFilePathRule\Fixture;
+
+final class SkipClassConsts
+{
+    /**
+     * @var string[]
+     */
+    private const SUFFIXES = ['neon', 'yaml', 'xml', 'yml', 'twig', 'latte', 'blade.php', 'tpl'];
+}

--- a/tests/Rules/Explicit/NoRelativeFilePathRule/NoRelativeFilePathRuleTest.php
+++ b/tests/Rules/Explicit/NoRelativeFilePathRule/NoRelativeFilePathRuleTest.php
@@ -33,6 +33,7 @@ final class NoRelativeFilePathRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipSimpleString.php', []];
         yield [__DIR__ . '/Fixture/SkipNotAFileExtension.php', []];
         yield [__DIR__ . '/Fixture/SkipUrls.php', []];
+        yield [__DIR__ . '/Fixture/SkipClassConsts.php', []];
 
         $errorMessage = sprintf(NoRelativeFilePathRule::ERROR_MESSAGE, 'some_relative_path.txt');
         yield [__DIR__ . '/Fixture/RelativeFilePath.php', [[$errorMessage, 11]]];


### PR DESCRIPTION
I think class constants should be allowed to contain any relative paths

refs https://github.com/rectorphp/rector-src/pull/3649#discussion_r1174623040