### PR TITLE
Remove phpstan/phpdoc-parser dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": ">=8.1",
         "nikic/php-parser": "^4.15.3",
         "nette/utils": "^3.2.9",
-        "phpstan/phpdoc-parser": "^1.16.1",
         "webmozart/assert": "^1.11",
         "symplify/rule-doc-generator-contracts": "^11.1.26"
     },

--- a/src/NodeAnalyzer/ArrayAnalyzer.php
+++ b/src/NodeAnalyzer/ArrayAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\NodeAnalyzer;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
@@ -13,12 +14,12 @@ final class ArrayAnalyzer
     public function isArrayWithStringKey(Array_ $array): bool
     {
         foreach ($array->items as $arrayItem) {
-            if ($arrayItem === null) {
+            if (!$arrayItem instanceof ArrayItem) {
                 continue;
             }
 
             /** @var ArrayItem $arrayItem */
-            if ($arrayItem->key === null) {
+            if (!$arrayItem->key instanceof Expr) {
                 continue;
             }
 

--- a/src/NodeAnalyzer/CacheIfAnalyzer.php
+++ b/src/NodeAnalyzer/CacheIfAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\NodeAnalyzer;
 
+use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
@@ -22,7 +23,7 @@ final class CacheIfAnalyzer
 
     public function isDefaultNullAssign(If_ $if): bool
     {
-        if ($if->else !== null) {
+        if ($if->else instanceof Else_) {
             return false;
         }
 

--- a/src/NodeAnalyzer/IfResemblingMatchAnalyzer.php
+++ b/src/NodeAnalyzer/IfResemblingMatchAnalyzer.php
@@ -29,7 +29,7 @@ final class IfResemblingMatchAnalyzer
         $comparedExprContent = [];
 
         foreach ($ifsAndCondExprs as $ifAndCondExpr) {
-            if ($ifAndCondExpr->getCondExpr() === null) {
+            if (!$ifAndCondExpr->getCondExpr() instanceof Expr) {
                 continue;
             }
 

--- a/src/NodeFinder/ReturnNodeFinder.php
+++ b/src/NodeFinder/ReturnNodeFinder.php
@@ -49,7 +49,7 @@ final class ReturnNodeFinder
                 return null;
             }
 
-            if ($node->expr === null) {
+            if (!$node->expr instanceof Expr) {
                 return null;
             }
 

--- a/src/Reflection/MethodNodeAnalyser.php
+++ b/src/Reflection/MethodNodeAnalyser.php
@@ -12,7 +12,7 @@ final class MethodNodeAnalyser
 {
     public function hasParentVendorLock(Scope $scope, string $methodName): bool
     {
-        return $this->matchFirstParentClassMethod($scope, $methodName) !== null;
+        return $this->matchFirstParentClassMethod($scope, $methodName) instanceof MethodReflection;
     }
 
     public function matchFirstParentClassMethod(Scope $scope, string $methodName): ?MethodReflection

--- a/src/Rules/BoolishClassMethodPrefixRule.php
+++ b/src/Rules/BoolishClassMethodPrefixRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
@@ -126,7 +127,7 @@ CODE_SAMPLE
     private function areOnlyBoolReturnNodes(array $returns, Scope $scope): bool
     {
         foreach ($returns as $return) {
-            if ($return->expr === null) {
+            if (!$return->expr instanceof Expr) {
                 continue;
             }
 

--- a/src/Rules/Complexity/ForbiddenNamedArgumentsRule.php
+++ b/src/Rules/Complexity/ForbiddenNamedArgumentsRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules\Complexity;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node;
 use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
@@ -54,7 +55,7 @@ CODE_SAMPLE
     public function processNode(Node $node, Scope $scope): array
     {
         foreach ($node->getArgs() as $arg) {
-            if ($arg->name === null) {
+            if (!$arg->name instanceof Identifier) {
                 continue;
             }
 

--- a/src/Rules/ForbiddenMultipleClassLikeInOneFileRule.php
+++ b/src/Rules/ForbiddenMultipleClassLikeInOneFileRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeFinder;
@@ -48,7 +49,7 @@ final class ForbiddenMultipleClassLikeInOneFileRule implements Rule, DocumentedR
 
         $findclassLikes = [];
         foreach ($classLikes as $classLike) {
-            if ($classLike->name === null) {
+            if (!$classLike->name instanceof Identifier) {
                 continue;
             }
 

--- a/src/Rules/NoConstructorInTestRule.php
+++ b/src/Rules/NoConstructorInTestRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PHPStan\Reflection\ClassReflection;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
@@ -46,7 +47,7 @@ final class NoConstructorInTestRule implements Rule, DocumentedRuleInterface
         }
 
         // no parent class, probably not a test case
-        if ($classReflection->getParentClass() === null) {
+        if (!$classReflection->getParentClass() instanceof ClassReflection) {
             return [];
         }
 

--- a/src/Rules/PreventParentMethodVisibilityOverrideRule.php
+++ b/src/Rules/PreventParentMethodVisibilityOverrideRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PHPStan\Reflection\ClassReflection;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
@@ -43,7 +44,7 @@ final class PreventParentMethodVisibilityOverrideRule implements Rule, Documente
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($scope->getClassReflection() === null) {
+        if (!$scope->getClassReflection() instanceof ClassReflection) {
             return [];
         }
 

--- a/src/Rules/RequireAttributeNameRule.php
+++ b/src/Rules/RequireAttributeNameRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PhpParser\Node\Identifier;
 use Attribute;
 use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
@@ -77,7 +78,7 @@ CODE_SAMPLE
             }
 
             foreach ($attribute->args as $arg) {
-                if ($arg->name !== null) {
+                if ($arg->name instanceof Identifier) {
                     continue;
                 }
 

--- a/src/Rules/SeeAnnotationToTestRule.php
+++ b/src/Rules/SeeAnnotationToTestRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use PHPStan\PhpDoc\Tag\DeprecatedTag;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
@@ -75,7 +76,7 @@ final class SeeAnnotationToTestRule implements Rule, DocumentedRuleInterface, Co
 
         // skip deprectaed
         $deprecatedTags = $resolvedPhpDocBlock->getDeprecatedTag();
-        if ($deprecatedTags !== null) {
+        if ($deprecatedTags instanceof DeprecatedTag) {
             return [];
         }
 

--- a/src/Rules/Spotter/SwitchToMatchSpotterRule.php
+++ b/src/Rules/Spotter/SwitchToMatchSpotterRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules\Spotter;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
@@ -80,7 +81,7 @@ CODE_SAMPLE
     private function hasDefaultCase(Switch_ $switch): bool
     {
         foreach ($switch->cases as $case) {
-            if ($case->cond === null) {
+            if (!$case->cond instanceof Expr) {
                 return true;
             }
         }
@@ -91,7 +92,7 @@ CODE_SAMPLE
     private function isMatchingSwitch(Switch_ $switch): bool
     {
         foreach ($switch->cases as $case) {
-            if ($case->cond === null) {
+            if (!$case->cond instanceof Expr) {
                 continue;
             }
 
@@ -106,7 +107,7 @@ CODE_SAMPLE
             }
 
             $onlyStmt = $case->stmts[0];
-            if ($onlyStmt instanceof Return_ && $onlyStmt->expr !== null) {
+            if ($onlyStmt instanceof Return_ && $onlyStmt->expr instanceof Expr) {
                 continue;
             }
 


### PR DESCRIPTION
Phpstan itself ships the phpdoc parser dependency, that one should be used to avoid conflicts. Refer to https://github.com/phpstan/phpdoc-parser/issues/188