### PR TITLE
Remove type-coverage-rules.neon from collector-rules.neon

### DIFF
--- a/config/collector-rules.neon
+++ b/config/collector-rules.neon
@@ -1,6 +1,3 @@
-includes:
-    - type-coverage-rules.neon
-
 # these rule focus on the whole-project analysis, see https://phpstan.org/developing-extensions/collectors
 rules:
     - Symplify\PHPStanRules\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule


### PR DESCRIPTION
@TomasVotruba it seems removed from https://github.com/symplify/phpstan-rules/commit/d7e70a86702b966ce44aa7fc83bfd3a0ad55a5dc#diff-b27960a3ca2aeaf23e751a8b5c4d4d16e12e0696e7c5e58f20df634e204d5b1b

and cause error in rector-src usage:

https://github.com/rectorphp/rector-src/actions/runs/4994611471/jobs/8945410708#step:5:12