### PR TITLE
Change NoReturnArrayVariableListRule to ignore array spreads

### DIFF
--- a/src/Rules/NoReturnArrayVariableListRule.php
+++ b/src/Rules/NoReturnArrayVariableListRule.php
@@ -156,6 +156,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($item->unpack === true) {
+                continue;
+            }
+
             ++$exprCount;
         }
 

--- a/tests/Rules/NoReturnArrayVariableListRule/Fixture/SkipArraySpreads.php
+++ b/tests/Rules/NoReturnArrayVariableListRule/Fixture/SkipArraySpreads.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoReturnArrayVariableListRule\Fixture;
+
+final class SkipArraySpreads
+{
+    public function run($value)
+    {
+        $a = [1, 2, 3];
+        $b = [4, 5, 6];
+        return [...$a, ...$b];
+    }
+}
+

--- a/tests/Rules/NoReturnArrayVariableListRule/NoReturnArrayVariableListRuleTest.php
+++ b/tests/Rules/NoReturnArrayVariableListRule/NoReturnArrayVariableListRuleTest.php
@@ -30,6 +30,7 @@ final class NoReturnArrayVariableListRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipNews.php', []];
         yield [__DIR__ . '/Fixture/ValueObject/SkipValueObject.php', []];
         yield [__DIR__ . '/Fixture/SkipParentMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipArraySpreads.php', []];
     }
 
     /**


### PR DESCRIPTION
Many times we return an array which contains a number of array spreads in order to merge all these arrays and return a single one:

```
return [...$firstSetOfResults, ...$secondSetOfResults];
```

The `NoReturnArrayVariableListRule` sees that we are returning an array composed of two expressions and will return an error asking us to use a value object instead. This is clearly not appropriate for this case

This PR fixes this problem by ignoring array spreads when counting the number of expressions in the returned array