### PR TITLE
[doctrine] Add NoGetRepositoryOnServiceRepositoryEntityRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,6 +1221,71 @@ final class SomeRepository
 
 <br>
 
+### NoGetRepositoryOnServiceRepositoryEntityRule
+
+Instead of calling "->getRepository(...::class)" service locator, inject service repository via constructor and use it directly
+
+```yaml
+rules:
+    - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule
+```
+
+<br>
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=SomeRepository::class)
+ */
+class SomeEntity
+{
+}
+```
+
+<br>
+
+```php
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+
+final class SomeEntityRepository extends ServiceEntityRepository
+{
+}
+```
+
+<br>
+
+```php
+use Doctrine\ORM\EntityManagerInterface;
+
+final class SomeService
+{
+    public function run(EntityManagerInterface $entityManager)
+    {
+        return $this->entityManager->getRepository(SomeEntity::class);
+    }
+}
+```
+
+:x:
+
+<br>
+
+```php
+use Doctrine\ORM\EntityManagerInterface;
+
+final class SomeService
+{
+    public function __construct(private SomeEntityRepository $someEntityRepository)
+    {
+    }
+}
+```
+
+:+1:
+
+<br>
+
 ### NoRepositoryCallInDataFixtureRule
 
 Repository should not be called in data fixtures, as it can lead to tight coupling

--- a/config/doctrine-rules.neon
+++ b/config/doctrine-rules.neon
@@ -2,6 +2,7 @@ rules:
     - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOutsideServiceRule
     - Symplify\PHPStanRules\Rules\Doctrine\NoParentRepositoryRule
     - Symplify\PHPStanRules\Rules\Doctrine\NoRepositoryCallInDataFixtureRule
+    - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule
 
     # test fixtures
     - Symplify\PHPStanRules\Rules\Doctrine\RequireQueryBuilderOnRepositoryRule

--- a/src/Doctrine/RepositoryClassResolver.php
+++ b/src/Doctrine/RepositoryClassResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Doctrine;
+
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Exception\ShouldNotHappenException;
+
+final readonly class RepositoryClassResolver
+{
+    /**
+     * @var string
+     */
+    private const QUOTED_REPOSITORY_CLASS_REGEX = '#repositoryClass=\"(?<repositoryClass>.*?)\"#';
+
+    /**
+     * @var string
+     */
+    private const USE_REPOSITORY_REGEX = '#use (?<repositoryClass>.*?Repository);#';
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function resolveFromEntityClass(string $entityClassName): ?string
+    {
+        if (! $this->reflectionProvider->hasClass($entityClassName)) {
+            throw new ShouldNotHappenException();
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($entityClassName);
+
+        $entityClassFileName = $classReflection->getFileName();
+        if ($entityClassFileName === null) {
+            return null;
+        }
+
+        $entityFileContents = FileSystem::read($entityClassFileName);
+
+        // match repositoryClass="..." in entity
+        $match = Strings::match($entityFileContents, self::QUOTED_REPOSITORY_CLASS_REGEX);
+
+        if (! isset($match['repositoryClass'])) {
+            // try fallback to repository ::class + use import
+
+            $repositoryUseMatch = Strings::match($entityFileContents, self::USE_REPOSITORY_REGEX);
+            if (isset($repositoryUseMatch['repositoryClass'])) {
+                $repositoryClass = $repositoryUseMatch['repositoryClass'];
+            } else {
+                // unable to resolve
+                return null;
+            }
+        } else {
+            $repositoryClass = $match['repositoryClass'];
+        }
+
+        if (! $this->reflectionProvider->hasClass($repositoryClass)) {
+            throw new ShouldNotHappenException(
+                sprintf('Repository class "%s" for entity "%s" does not exist', $repositoryClass, $entityClassName)
+            );
+        }
+
+        return $repositoryClass;
+    }
+}

--- a/src/Enum/ClassName.php
+++ b/src/Enum/ClassName.php
@@ -9,11 +9,6 @@ final class ClassName
     /**
      * @var string
      */
-    public const PHPUNIT_TEST_CASE = 'PHPUnit\Framework\TestCase';
-
-    /**
-     * @var string
-     */
     public const SNIFF = 'PHP_CodeSniffer\Sniffs\Sniff';
 
     /**
@@ -35,16 +30,6 @@ final class ClassName
      * @var string
      */
     public const RECTOR_ATTRIBUTE_KEY = 'Rector\NodeTypeResolver\Node\AttributeKey';
-
-    /**
-     * @var string
-     */
-    public const DOCTRINE_FIXTURE_INTERFACE = 'Doctrine\Common\DataFixtures\FixtureInterface';
-
-    /**
-     * @var string
-     */
-    public const ENTITY_REPOSITORY_CLASS = 'Doctrine\ORM\EntityRepository';
 
     /**
      * @var string

--- a/src/Enum/DoctrineClass.php
+++ b/src/Enum/DoctrineClass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Enum;
+
+final class DoctrineClass
+{
+    /**
+     * @var string
+     */
+    public const ODM_SERVICE_REPOSITORY = 'Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository';
+
+    /**
+     * @var string
+     */
+    public const ORM_SERVICE_REPOSITORY = 'Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository';
+
+    /**
+     * @var string
+     */
+    public const FIXTURE_INTERFACE = 'Doctrine\Common\DataFixtures\FixtureInterface';
+
+    /**
+     * @var string
+     */
+    public const ENTITY_REPOSITORY = 'Doctrine\ORM\EntityRepository';
+}

--- a/src/Enum/DoctrineRuleIdentifier.php
+++ b/src/Enum/DoctrineRuleIdentifier.php
@@ -6,13 +6,15 @@ namespace Symplify\PHPStanRules\Enum;
 
 final class DoctrineRuleIdentifier
 {
-    public const DOCTRINE_NO_GET_REPOSITORY_OUTSIDE_SERVICE = 'doctrine.noGetRepositoryOutsideService';
+    public const NO_GET_REPOSITORY_OUTSIDE_SERVICE = 'doctrine.noGetRepositoryOutsideService';
 
-    public const DOCTRINE_NO_REPOSITORY_CALL_IN_DATA_FIXTURES = 'doctrine.noRepositoryCallInDataFixtures';
+    public const NO_REPOSITORY_CALL_IN_DATA_FIXTURES = 'doctrine.noRepositoryCallInDataFixtures';
 
-    public const DOCTRINE_NO_PARENT_REPOSITORY = 'doctrine.noParentRepository';
+    public const NO_PARENT_REPOSITORY = 'doctrine.noParentRepository';
 
     public const NO_ENTITY_MOCKING = 'doctrine.noEntityMocking';
 
     public const REQUIRE_QUERY_BUILDER_ON_REPOSITORY = 'doctrine.requireQueryBuilderOnRepository';
+
+    public const INJECT_SERVICE_REPOSITORY = 'doctrine.injectServiceRepository';
 }

--- a/src/Enum/TestClassName.php
+++ b/src/Enum/TestClassName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Enum;
+
+final class TestClassName
+{
+    /**
+     * @var string
+     */
+    public const PHPUNIT_TEST_CASE = 'PHPUnit\Framework\TestCase';
+
+    /**
+     * @var string
+     */
+    public const BEHAT_CONTEXT = 'Behat\Behat\Context\Context';
+}

--- a/src/Rules/ClassNameRespectsParentSuffixRule.php
+++ b/src/Rules/ClassNameRespectsParentSuffixRule.php
@@ -16,6 +16,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use Symplify\PHPStanRules\Enum\ClassName;
 use Symplify\PHPStanRules\Enum\RuleIdentifier;
 use Symplify\PHPStanRules\Enum\SymfonyClass;
+use Symplify\PHPStanRules\Enum\TestClassName;
 use Symplify\PHPStanRules\Naming\ClassToSuffixResolver;
 
 /**
@@ -37,7 +38,7 @@ final class ClassNameRespectsParentSuffixRule implements Rule
         SymfonyClass::EVENT_SUBSCRIBER_INTERFACE,
         SymfonyClass::SYMFONY_ABSTRACT_CONTROLLER,
         ClassName::SNIFF,
-        ClassName::PHPUNIT_TEST_CASE,
+        TestClassName::PHPUNIT_TEST_CASE,
         Exception::class,
         'PhpCsFixer\Fixer\FixerInterface',
         Rule::class,

--- a/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
+++ b/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules\Doctrine;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use Symplify\PHPStanRules\Doctrine\RepositoryClassResolver;
+use Symplify\PHPStanRules\Enum\DoctrineClass;
+use Symplify\PHPStanRules\Enum\DoctrineRuleIdentifier;
+use Symplify\PHPStanRules\Enum\TestClassName;
+
+/**
+ * @implements Rule<MethodCall>
+ *
+ * @see \Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\NoGetRepositoryOnServiceRepositoryEntityRuleTest
+ */
+final readonly class NoGetRepositoryOnServiceRepositoryEntityRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Instead of calling "->getRepository(%s::class)" service locator, inject service repository "%s" via constructor and use it directly';
+
+    private RepositoryClassResolver $repositoryClassResolver;
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider
+    ) {
+        $this->repositoryClassResolver = new RepositoryClassResolver($reflectionProvider);
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier || $node->name->toString() !== 'getRepository') {
+            return [];
+        }
+
+        $repositoryClassName = $this->resolveRepositoryClassFromGetRepositoryEntity($node, $scope);
+        if (! is_string($repositoryClassName)) {
+            return [];
+        }
+
+        if ($this->shouldSkipTestClass($scope)) {
+            return [];
+        }
+
+        // is the repository service one?
+        if (! $this->isServiceRepositoryClassReflection($repositoryClassName)) {
+            return [];
+        }
+
+        /** @var string $entityClassName */
+        $entityClassName = $this->resolveEntityClass($node, $scope);
+        $shortEntityClassName = Strings::after($entityClassName, '\\', -1);
+
+        $errorMessage = sprintf(self::ERROR_MESSAGE, $shortEntityClassName, $repositoryClassName);
+
+        $identifierRuleError = RuleErrorBuilder::message($errorMessage)
+            ->identifier(DoctrineRuleIdentifier::INJECT_SERVICE_REPOSITORY)
+            ->build();
+
+        return [$identifierRuleError];
+    }
+
+    private function shouldSkipTestClass(Scope $scope): bool
+    {
+        // skip tests and behat Context
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        if ($classReflection->isSubclassOf(TestClassName::PHPUNIT_TEST_CASE)) {
+            return true;
+        }
+
+        return $classReflection->isSubclassOf(TestClassName::BEHAT_CONTEXT);
+    }
+
+    private function resolveRepositoryClassFromGetRepositoryEntity(MethodCall $methodCall, Scope $scope): ?string
+    {
+        $entityClassName = $this->resolveEntityClass($methodCall, $scope);
+        if ($entityClassName === null) {
+            return null;
+        }
+
+        return $this->repositoryClassResolver->resolveFromEntityClass($entityClassName);
+    }
+
+    private function resolveEntityClass(MethodCall $methodCall, Scope $scope): ?string
+    {
+        if (count($methodCall->getArgs()) !== 1) {
+            return null;
+        }
+
+        $firstArgument = $methodCall->getArgs()[0]->value;
+
+        $entityClassType = $scope->getType($firstArgument);
+        if (! $entityClassType instanceof ConstantStringType) {
+            return null;
+        }
+
+        return $entityClassType->getValue();
+    }
+
+    private function isServiceRepositoryClassReflection(string $repositoryClassName): bool
+    {
+        if (! $this->reflectionProvider->hasClass($repositoryClassName)) {
+            return false;
+        }
+
+        $repositoryClassReflection = $this->reflectionProvider->getClass($repositoryClassName);
+        if ($repositoryClassReflection->isSubclassOf(DoctrineClass::ODM_SERVICE_REPOSITORY)) {
+            return true;
+        }
+
+        return $repositoryClassReflection->isSubclassOf(DoctrineClass::ORM_SERVICE_REPOSITORY);
+    }
+}

--- a/src/Rules/Doctrine/NoGetRepositoryOutsideServiceRule.php
+++ b/src/Rules/Doctrine/NoGetRepositoryOutsideServiceRule.php
@@ -44,7 +44,7 @@ final class NoGetRepositoryOutsideServiceRule implements Rule
 
         if (! $scope->isInClass()) {
             $ruleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-                ->identifier(DoctrineRuleIdentifier::DOCTRINE_NO_GET_REPOSITORY_OUTSIDE_SERVICE)
+                ->identifier(DoctrineRuleIdentifier::NO_GET_REPOSITORY_OUTSIDE_SERVICE)
                 ->build();
 
             return [$ruleError];
@@ -57,7 +57,7 @@ final class NoGetRepositoryOutsideServiceRule implements Rule
         }
 
         $ruleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(DoctrineRuleIdentifier::DOCTRINE_NO_GET_REPOSITORY_OUTSIDE_SERVICE)
+            ->identifier(DoctrineRuleIdentifier::NO_GET_REPOSITORY_OUTSIDE_SERVICE)
             ->build();
 
         return [$ruleError];

--- a/src/Rules/Doctrine/NoParentRepositoryRule.php
+++ b/src/Rules/Doctrine/NoParentRepositoryRule.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use Symplify\PHPStanRules\Enum\ClassName;
+use Symplify\PHPStanRules\Enum\DoctrineClass;
 use Symplify\PHPStanRules\Enum\DoctrineRuleIdentifier;
 
 /**
@@ -43,12 +43,12 @@ final class NoParentRepositoryRule implements Rule
         }
 
         $parentClass = $node->extends->toString();
-        if ($parentClass !== ClassName::ENTITY_REPOSITORY_CLASS) {
+        if ($parentClass !== DoctrineClass::ENTITY_REPOSITORY) {
             return [];
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(DoctrineRuleIdentifier::DOCTRINE_NO_PARENT_REPOSITORY)
+            ->identifier(DoctrineRuleIdentifier::NO_PARENT_REPOSITORY)
             ->build();
 
         return [$identifierRuleError];

--- a/src/Rules/Doctrine/NoRepositoryCallInDataFixtureRule.php
+++ b/src/Rules/Doctrine/NoRepositoryCallInDataFixtureRule.php
@@ -11,7 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use Symplify\PHPStanRules\Enum\ClassName;
+use Symplify\PHPStanRules\Enum\DoctrineClass;
 use Symplify\PHPStanRules\Enum\DoctrineRuleIdentifier;
 use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoRepositoryCallInDataFixtureRule\NoRepositoryCallInDataFixtureRuleTest;
 
@@ -56,7 +56,7 @@ final class NoRepositoryCallInDataFixtureRule implements Rule
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(DoctrineRuleIdentifier::DOCTRINE_NO_REPOSITORY_CALL_IN_DATA_FIXTURES)
+            ->identifier(DoctrineRuleIdentifier::NO_REPOSITORY_CALL_IN_DATA_FIXTURES)
             ->build();
 
         return [$identifierRuleError];
@@ -69,6 +69,6 @@ final class NoRepositoryCallInDataFixtureRule implements Rule
         }
 
         $classReflection = $scope->getClassReflection();
-        return $classReflection->isSubclassOf(ClassName::DOCTRINE_FIXTURE_INTERFACE);
+        return $classReflection->isSubclassOf(DoctrineClass::FIXTURE_INTERFACE);
     }
 }

--- a/src/Rules/Doctrine/RequireQueryBuilderOnRepositoryRule.php
+++ b/src/Rules/Doctrine/RequireQueryBuilderOnRepositoryRule.php
@@ -11,7 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
-use Symplify\PHPStanRules\Enum\ClassName;
+use Symplify\PHPStanRules\Enum\DoctrineClass;
 use Symplify\PHPStanRules\Enum\DoctrineRuleIdentifier;
 
 /**
@@ -48,7 +48,7 @@ final class RequireQueryBuilderOnRepositoryRule implements Rule
         }
 
         // we safe as both select() + from() calls are made on the repository
-        if ($callerType->isInstanceOf(ClassName::ENTITY_REPOSITORY_CLASS)->yes()) {
+        if ($callerType->isInstanceOf(DoctrineClass::ENTITY_REPOSITORY)->yes()) {
             return [];
         }
 

--- a/src/Rules/SeeAnnotationToTestRule.php
+++ b/src/Rules/SeeAnnotationToTestRule.php
@@ -15,8 +15,8 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use Symplify\PHPStanRules\Enum\ClassName;
 use Symplify\PHPStanRules\Enum\RuleIdentifier;
+use Symplify\PHPStanRules\Enum\TestClassName;
 use Symplify\PHPStanRules\PhpDoc\PhpDocResolver;
 use Symplify\PHPStanRules\PhpDoc\SeePhpDocTagNodesFinder;
 
@@ -113,7 +113,7 @@ final readonly class SeeAnnotationToTestRule implements Rule
                 continue;
             }
 
-            if (is_a($seeTag->value->value, ClassName::PHPUNIT_TEST_CASE, true)) {
+            if (is_a($seeTag->value->value, TestClassName::PHPUNIT_TEST_CASE, true)) {
                 return true;
             }
         }

--- a/stubs/Doctrine/Bundle/DoctrineBundle/Repository/ServiceEntityRepository.php
+++ b/stubs/Doctrine/Bundle/DoctrineBundle/Repository/ServiceEntityRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+if (class_exists('Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository')) {
+    return;
+}
+
+abstract class ServiceEntityRepository
+{
+}

--- a/stubs/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/stubs/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB;
+
+if (class_exists('Doctrine\ODM\MongoDB\DocumentManager')) {
+    return;
+}
+
+abstract class DocumentManager
+{
+    public function getRepository(string $class)
+    {
+    }
+}

--- a/stubs/Doctrine/ORM/EntityManagerInterface.php
+++ b/stubs/Doctrine/ORM/EntityManagerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\ORM;
+
+if (class_exists('Doctrine\ORM\EntityManagerInterface')) {
+    return;
+}
+
+interface EntityManagerInterface
+{
+    public function getRepository(string $class): object;
+}

--- a/stubs/Doctrine/ORM/EntityRepository.php
+++ b/stubs/Doctrine/ORM/EntityRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\ORM;
+
+if (class_exists('Doctrine\ORM\EntityRepository')) {
+    return;
+}
+
+class EntityRepository
+{
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Fixture/GetRepositoryOnServiceAwareEntity.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Fixture/GetRepositoryOnServiceAwareEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source\SomeEntity;
+
+class GetRepositoryOnServiceAwareEntity
+{
+    public function run(EntityManagerInterface $entityManager)
+    {
+        $someRepository = $entityManager->getRepository(SomeEntity::class);
+    }
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Fixture/SkipGetRepositoryOnNormalRepository.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Fixture/SkipGetRepositoryOnNormalRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source\NormalEntity;
+
+class SkipGetRepositoryOnNormalRepository
+{
+    public function run(EntityManagerInterface $entityManager)
+    {
+        $someRepository = $entityManager->getRepository(NormalEntity::class);
+    }
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/NoGetRepositoryOnServiceRepositoryEntityRuleTest.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/NoGetRepositoryOnServiceRepositoryEntityRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule;
+
+use Iterator;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule;
+use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source\SomeServiceRepository;
+
+final class NoGetRepositoryOnServiceRepositoryEntityRuleTest extends RuleTestCase
+{
+    /**
+     * @param mixed[] $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        $errorMessage = sprintf(NoGetRepositoryOnServiceRepositoryEntityRule::ERROR_MESSAGE, 'SomeEntity', SomeServiceRepository::class);
+
+        yield [__DIR__ . '/Fixture/GetRepositoryOnServiceAwareEntity.php', [[
+            $errorMessage,
+            14,
+        ]]];
+
+        yield [__DIR__ . '/Fixture/SkipGetRepositoryOnNormalRepository.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        $reflectionProvider = self::getContainer()->getByType(ReflectionProvider::class);
+
+        return new NoGetRepositoryOnServiceRepositoryEntityRule($reflectionProvider);
+    }
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/NormalEntity.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/NormalEntity.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source\NormalRepository;
+
+/**
+ * @ORM\Entity(repositoryClass=NormalRepository::class)
+ */
+class NormalEntity
+{
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/NormalRepository.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/NormalRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source;
+
+use Doctrine\ORM\EntityRepository;
+
+final class NormalRepository extends EntityRepository
+{
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/SomeEntity.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/SomeEntity.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source\SomeServiceRepository;
+
+/**
+ * @ORM\Entity(repositoryClass=SomeServiceRepository::class)
+ */
+class SomeEntity
+{
+}

--- a/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/SomeServiceRepository.php
+++ b/tests/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule/Source/SomeServiceRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule\Source;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+
+final class SomeServiceRepository extends ServiceEntityRepository
+{
+}


### PR DESCRIPTION
Instead of calling "->getRepository(...::class)" service locator, inject service repository via constructor and use it directly

```yaml
rules:
    - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule
```

<br>

```php
use Doctrine\ORM\Mapping as ORM;
/**
 * @ORM\Entity(repositoryClass=SomeRepository::class)
 */
class SomeEntity
{
}
```

<br>

```php
use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
final class SomeEntityRepository extends ServiceEntityRepository
{
}
```

<br>

```php
use Doctrine\ORM\EntityManagerInterface;
final class SomeService
{
    public function run(EntityManagerInterface $entityManager)
    {
        return $this->entityManager->getRepository(SomeEntity::class);
    }
}
```

:x:

<br>

```php
use Doctrine\ORM\EntityManagerInterface;
final class SomeService
{
    public function __construct(private SomeEntityRepository $someEntityRepository)
    {
    }
}
```

:+1: