### PR TITLE
Bump to PHPStan ^2.1.8 and change deprecated ClassReflection::isSubClassOf() to ClassReflection::is() for PHPStan ^2.1.8

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.8",
         "nette/utils": "^3.2|^4.0",
         "webmozart/assert": "^1.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.2",
         "webmozart/assert": "^1.11",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.8",
         "nette/utils": "^3.2|^4.0",
         "phpstan/phpdoc-parser": "^2.0"
     },

--- a/src/NodeAnalyzer/EnumAnalyzer.php
+++ b/src/NodeAnalyzer/EnumAnalyzer.php
@@ -34,7 +34,7 @@ final readonly class EnumAnalyzer
             return true;
         }
 
-        if ($classReflection->isSubclassOf('MyCLabs\Enum\Enum')) {
+        if ($classReflection->is('MyCLabs\Enum\Enum')) {
             return true;
         }
 

--- a/src/Rules/ClassNameRespectsParentSuffixRule.php
+++ b/src/Rules/ClassNameRespectsParentSuffixRule.php
@@ -93,7 +93,7 @@ final class ClassNameRespectsParentSuffixRule implements Rule
     private function processClassNameAndShort(ClassReflection $classReflection): array
     {
         foreach ($this->parentClasses as $parentClass) {
-            if (! $classReflection->isSubclassOf($parentClass)) {
+            if (! $classReflection->is($parentClass)) {
                 continue;
             }
 

--- a/src/Rules/Complexity/NoJustPropertyAssignRule.php
+++ b/src/Rules/Complexity/NoJustPropertyAssignRule.php
@@ -141,7 +141,7 @@ final readonly class NoJustPropertyAssignRule implements Rule
             $classReflection = $scope->getClassReflection();
 
             // skip Symfony form types as rather static
-            if ($classReflection->isSubclassOf(AbstractType::class)) {
+            if ($classReflection->is(AbstractType::class)) {
                 return true;
             }
         }

--- a/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
+++ b/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
@@ -90,11 +90,11 @@ final readonly class NoGetRepositoryOnServiceRepositoryEntityRule implements Rul
             return true;
         }
 
-        if ($classReflection->isSubclassOf(TestClassName::PHPUNIT_TEST_CASE)) {
+        if ($classReflection->is(TestClassName::PHPUNIT_TEST_CASE)) {
             return true;
         }
 
-        return $classReflection->isSubclassOf(TestClassName::BEHAT_CONTEXT);
+        return $classReflection->is(TestClassName::BEHAT_CONTEXT);
     }
 
     private function resolveRepositoryClassFromGetRepositoryEntity(MethodCall $methodCall, Scope $scope): ?string
@@ -130,10 +130,10 @@ final readonly class NoGetRepositoryOnServiceRepositoryEntityRule implements Rul
         }
 
         $repositoryClassReflection = $this->reflectionProvider->getClass($repositoryClassName);
-        if ($repositoryClassReflection->isSubclassOf(DoctrineClass::ODM_SERVICE_REPOSITORY)) {
+        if ($repositoryClassReflection->is(DoctrineClass::ODM_SERVICE_REPOSITORY)) {
             return true;
         }
 
-        return $repositoryClassReflection->isSubclassOf(DoctrineClass::ORM_SERVICE_REPOSITORY);
+        return $repositoryClassReflection->is(DoctrineClass::ORM_SERVICE_REPOSITORY);
     }
 }

--- a/src/Rules/Doctrine/NoRepositoryCallInDataFixtureRule.php
+++ b/src/Rules/Doctrine/NoRepositoryCallInDataFixtureRule.php
@@ -69,6 +69,6 @@ final class NoRepositoryCallInDataFixtureRule implements Rule
         }
 
         $classReflection = $scope->getClassReflection();
-        return $classReflection->isSubclassOf(DoctrineClass::FIXTURE_INTERFACE);
+        return $classReflection->is(DoctrineClass::FIXTURE_INTERFACE);
     }
 }

--- a/src/Rules/Domain/RequireExceptionNamespaceRule.php
+++ b/src/Rules/Domain/RequireExceptionNamespaceRule.php
@@ -37,7 +37,7 @@ final class RequireExceptionNamespaceRule implements Rule
             return [];
         }
 
-        if (! $classReflection->isSubclassOf('Exception')) {
+        if (! $classReflection->is('Exception')) {
             return [];
         }
 

--- a/src/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule.php
+++ b/src/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule.php
@@ -110,12 +110,12 @@ final class PhpUpgradeDowngradeRegisteredInSetRule implements Rule
             return null;
         }
 
-        if (! $classReflection->isSubclassOf(ClassName::RECTOR)) {
+        if (! $classReflection->is(ClassName::RECTOR)) {
             return null;
         }
 
         // configurable Rector can be registered optionally
-        if ($classReflection->isSubclassOf(ClassName::CONFIGURABLE_RECTOR)) {
+        if ($classReflection->is(ClassName::CONFIGURABLE_RECTOR)) {
             return null;
         }
 

--- a/src/Rules/SeeAnnotationToTestRule.php
+++ b/src/Rules/SeeAnnotationToTestRule.php
@@ -95,7 +95,7 @@ final readonly class SeeAnnotationToTestRule implements Rule
         }
 
         foreach ($this->requiredSeeTypes as $requiredSeeType) {
-            if ($classReflection->isSubclassOf($requiredSeeType)) {
+            if ($classReflection->is($requiredSeeType)) {
                 return false;
             }
         }

--- a/src/Rules/Symfony/RequiredOnlyInAbstractRule.php
+++ b/src/Rules/Symfony/RequiredOnlyInAbstractRule.php
@@ -93,7 +93,7 @@ final class RequiredOnlyInAbstractRule implements Rule
         }
 
         foreach (self::SKIPPED_PARENT_TYPES as $skippedParentType) {
-            if ($classReflection->isSubclassOf($skippedParentType)) {
+            if ($classReflection->is($skippedParentType)) {
                 return true;
             }
         }

--- a/src/Symfony/NodeAnalyzer/SymfonyCommandAnalyzer.php
+++ b/src/Symfony/NodeAnalyzer/SymfonyCommandAnalyzer.php
@@ -16,6 +16,6 @@ final class SymfonyCommandAnalyzer
         }
 
         $classReflection = $scope->getClassReflection();
-        return $classReflection->isSubclassOf(SymfonyClass::COMMAND);
+        return $classReflection->is(SymfonyClass::COMMAND);
     }
 }

--- a/src/Symfony/NodeAnalyzer/SymfonyControllerAnalyzer.php
+++ b/src/Symfony/NodeAnalyzer/SymfonyControllerAnalyzer.php
@@ -29,7 +29,7 @@ final class SymfonyControllerAnalyzer
 
         $classReflection = $scope->getClassReflection();
         foreach (self::CONTROLLER_TYPES as $controllerType) {
-            if ($classReflection->isSubclassOf($controllerType)) {
+            if ($classReflection->is($controllerType)) {
                 return true;
             }
         }

--- a/src/Testing/PHPUnitTestAnalyser.php
+++ b/src/Testing/PHPUnitTestAnalyser.php
@@ -22,7 +22,7 @@ final class PHPUnitTestAnalyser
             return false;
         }
 
-        return $classReflection->isSubclassOf(self::TEST_CASE_CLASS);
+        return $classReflection->is(self::TEST_CASE_CLASS);
     }
 
     /**


### PR DESCRIPTION
Similar with rector-src PR:

- https://github.com/rectorphp/rector-src/pull/6775

`ClassReflection::isSubClassOf()` is deprecated in latest PHPStan 2.1.8

https://github.com/phpstan/phpstan/releases/tag/2.1.8

The allowed string to parameter is now changed to use method `ClassReflection::is(string $className)`