### PR TITLE
Update README.md: removed old rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ composer require symplify/phpstan-rules --dev
 
 ## Usage
 
-Later, once you have most rules applied, it's best practice to include whole sets:
+Configuration should be added to your `phpstan.neon` file.
+
+<br>
+
+Once you have most rules applied, it's best practice to include whole sets:
 
 ```yaml
 includes:
@@ -30,8 +34,6 @@ includes:
 
     # project specific
     - vendor/symplify/phpstan-rules/config/rector-rules.neon
-    - vendor/symplify/phpstan-rules/config/doctrine-rules.neon
-    - vendor/symplify/phpstan-rules/config/symfony-rules.neon
 ```
 
 <br>
@@ -183,36 +185,6 @@ return __DIR__  . '/../fixtures/some_file.yml';
 
 :+1:
 
-
-<br>
-
-### NoConstructorOverrideRule
-
-Possible __construct() override, this can cause missing dependencies or setup
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\NoConstructorOverrideRule
-```
-
-```php
-class ParentClass
-{
-    public function __construct(private string $dependency)
-    {
-    }
-}
-
-class SomeClass extends ParentClass
-{
-    public function __construct()
-    {
-    }
-}
-```
-
-:x:
-
 <br>
 
 ```php
@@ -279,17 +251,6 @@ abstract class AbstractClass
 
 <br>
 
-### NoProtectedClassStmtRule
-
-Avoid protected class stmts as they yield unexpected behavior. Use clear interface contract instead
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Explicit\NoProtectedClassStmtRule
-```
-
-<br>
-
 ### ForbiddenArrayMethodCallRule
 
 Array method calls [$this, "method"] are not allowed. Use explicit method instead to help PhpStorm, PHPStan and Rector understand your code
@@ -314,32 +275,6 @@ usort($items, function (array $apples) {
 ```
 
 :+1:
-
-<br>
-
-### NoJustPropertyAssignRule
-
-Instead of assigning service property to a variable, use the property directly
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Complexity\NoJustPropertyAssignRule
-```
-
-```php
-class SomeClass
-{
-    // ...
-
-    public function run()
-    {
-        $someService = $this->someService;
-        $someService->run();
-    }
-}
-```
-
-:x:
 
 <br>
 
@@ -389,37 +324,6 @@ abstract class ParentClass
 ```
 
 :+1:
-
-<br>
-
-### ForbiddenNewArgumentRule
-
-Type "%s" is forbidden to be created manually with `new X()`. Use service and constructor injection instead
-
-```yaml
-services:
-    -
-        class: Symplify\PHPStanRules\Rules\ForbiddenNewArgumentRule
-        tag: [phpstan.rules.rule]
-        arguments:
-            forbiddenTypes:
-                - RepositoryService
-```
-
-↓
-
-```php
-class SomeService
-{
-    public function run()
-    {
-        $repositoryService = new RepositoryService();
-        $item = $repositoryService->get(1);
-    }
-}
-```
-
-:x:
 
 <br>
 
@@ -773,47 +677,6 @@ final class SomeClass
 
 <br>
 
-### NoTestMocksRule
-
-Mocking "%s" class is forbidden. Use direct/anonymous class instead for better static analysis
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoTestMocksRule
-```
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SkipApiMock extends TestCase
-{
-    public function test()
-    {
-        $someTypeMock = $this->createMock(SomeType::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SkipApiMock extends TestCase
-{
-    public function test()
-    {
-        $someTypeMock = new class() implements SomeType {};
-    }
-}
-```
-
-:+1:
-
-<br>
-
 ### PreferredClassRule
 
 Instead of "%s" class/interface use "%s"
@@ -909,98 +772,13 @@ class SomeClass extends SomeParentClass
 
 <br>
 
-### RequiredOnlyInAbstractRule
-
-`@required` annotation should be used only in abstract classes, to child classes can use clean `__construct()` service injection.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\RequiredOnlyInAbstractRule
-```
-
-<br>
-
-### RequireRouteNameToGenerateControllerRouteRule
-
-To pass a controller class to generate() method, the controller must have "#[Route(name: self::class)]" above the __invoke() method
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\RequireRouteNameToGenerateControllerRouteRule
-```
-
-<br>
-
-### SingleRequiredMethodRule
-
-There must be maximum 1 @required method in the class. Merge it to one to avoid possible injection collision or duplicated injects.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\SingleRequiredMethodRule
-```
-
-<br>
-
 ### RequireAttributeNameRule
-
-Attribute must have all names explicitly defined
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\RequireAttributeNameRule
-```
-
-```php
-use Symfony\Component\Routing\Annotation\Route;
-
-class SomeController
-{
-    #[Route("/path")]
-    public function someAction()
-    {
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\Routing\Annotation\Route;
-
-class SomeController
-{
-    #[Route(path: "/path")]
-    public function someAction()
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoRouteTrailingSlashPathRule
-
-Avoid trailing slash in route path, to prevent redirects and SEO issues
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoRouteTrailingSlashPathRule
-```
-
-<br>
-
-### RequireAttributeNamespaceRule
 
 Attribute must be located in "Attribute" namespace
 
 ```yaml
 rules:
-    - Symplify\PHPStanRules\Rules\Domain\RequireAttributeNamespaceRule
+    - Symplify\PHPStanRules\Rules\Domain\RequireAttributeNameRule
 ```
 
 ```php
@@ -1182,578 +960,7 @@ final class SomeClass
 
 <br>
 
-## 2. Doctrine-specific Rules
-
-### RequireQueryBuilderOnRepositoryRule
-
-Prevents using `$entityManager->createQueryBuilder('...')`,  use `$repository->createQueryBuilder()` as safer.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\RequireQueryBuilderOnRepositoryRule
-```
-
-<br>
-
-### NoGetRepositoryOutsideServiceRule
-
-Instead of getting repository from EntityManager, use constructor injection and service pattern to keep code clean
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOutsideServiceRule
-```
-
-```php
-class SomeClass
-{
-    public function run(EntityManagerInterface $entityManager)
-    {
-        return $entityManager->getRepository(SomeEntity::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-class SomeClass
-{
-    public function __construct(SomeEntityRepository $someEntityRepository)
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoParentRepositoryRule
-
-Repository should not extend parent repository, as it can lead to tight coupling
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\NoParentRepositoryRule
-```
-
-```php
-use Doctrine\ORM\EntityRepository;
-
-final class SomeRepository extends EntityRepository
-{
-}
-```
-
-:x:
-
-<br>
-
-```php
-final class SomeRepository
-{
-    public function __construct(EntityManagerInterface $entityManager)
-    {
-        $this->repository = $entityManager->getRepository(SomeEntity::class);
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoGetRepositoryOnServiceRepositoryEntityRule
-
-Instead of calling "->getRepository(...::class)" service locator, inject service repository via constructor and use it directly
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\NoGetRepositoryOnServiceRepositoryEntityRule
-```
-
-<br>
-
-```php
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity(repositoryClass=SomeRepository::class)
- */
-class SomeEntity
-{
-}
-```
-
-<br>
-
-```php
-use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-
-final class SomeEntityRepository extends ServiceEntityRepository
-{
-}
-```
-
-<br>
-
-```php
-use Doctrine\ORM\EntityManagerInterface;
-
-final class SomeService
-{
-    public function run(EntityManagerInterface $entityManager)
-    {
-        return $this->entityManager->getRepository(SomeEntity::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Doctrine\ORM\EntityManagerInterface;
-
-final class SomeService
-{
-    public function __construct(private SomeEntityRepository $someEntityRepository)
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoRepositoryCallInDataFixtureRule
-
-Repository should not be called in data fixtures, as it can lead to tight coupling
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\NoRepositoryCallInDataFixtureRule
-```
-
-```php
-use Doctrine\Common\DataFixtures\AbstractFixture;
-
-final class SomeFixture extends AbstractFixture
-{
-    public function load(ObjectManager $objectManager)
-    {
-        $someRepository = $objectManager->getRepository(SomeEntity::class);
-        $someEntity = $someRepository->get(1);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Doctrine\Common\DataFixtures\AbstractFixture;
-
-final class SomeFixture extends AbstractFixture
-{
-    public function load(ObjectManager $objectManager)
-    {
-        $someEntity = $this->getReference('some-entity-1');
-    }
-}
-```
-
-:+1:
-
-<br>
-
----
-
-<br>
-
-## 3. Symfony-specific Rules
-
-### FormTypeClassNameRule
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\FormTypeClassNameRule
-```
-
-Classes that extend `AbstractType` should have `*FormType` suffix, to make it clear it's a form class.
-
-<br>
-
-### NoConstructorAndRequiredTogetherRule
-
-Constructor injection and `#[Required]` method should not be used together in single class. Pick one, to keep architecture clean.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoConstructorAndRequiredTogetherRule
-```
-
-<br>
-
-### NoGetDoctrineInControllerRule
-
-Prevents using `$this->getDoctrine()` in controllers, to promote dependency injection.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoGetDoctrineInControllerRule
-```
-
-<br>
-
-### NoGetInControllerRule
-
-Prevents using `$this->get(...)` in controllers, to promote dependency injection.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoGetInControllerRule
-```
-
-<br>
-
-
-### NoGetInCommandRule
-
-Prevents using `$this->get(...)` in commands, to promote dependency injection.
-
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoGetInCommandRule
-```
-
-<br>
-
-
-### NoAbstractControllerConstructorRule
-
-Abstract controller should not have constructor, as it can lead to tight coupling. Use @required annotation instead
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoAbstractControllerConstructorRule
-```
-
-```php
-abstract class AbstractController extends Controller
-{
-    public function __construct(
-        private SomeService $someService
-    ) {
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-abstract class AbstractController extends Controller
-{
-    private $someService;
-
-    #[Required]
-    public function autowireAbstractController(SomeService $someService)
-    {
-        $this->someService = $someService;
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoRoutingPrefixRule
-
-Avoid global route prefixing. Use single place for paths in @Route/#[Route] and improve static analysis instead.
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoRoutingPrefixRule
-```
-
-
-```php
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-
-return static function (RoutingConfigurator $routingConfigurator): void {
-    $routingConfigurator->import(__DIR__ . '/some-path')
-        ->prefix('/some-prefix');
-};
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-
-return static function (RoutingConfigurator $routingConfigurator): void {
-    $routingConfigurator->import(__DIR__ . '/some-path');
-};
-```
-
-:+1:
-
-<br>
-
-### NoClassLevelRouteRule
-
-Avoid class-level route prefixing. Use method route to keep single source of truth and focus
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoClassLevelRouteRule
-```
-
-```php
-use Symfony\Component\Routing\Attribute\Route;
-
-#[Route('/some-prefix')]
-class SomeController
-{
-    #[Route('/some-action')]
-    public function someAction()
-    {
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\Routing\Attribute\Route;
-
-class SomeController
-{
-    #[Route('/some-prefix/some-action')]
-    public function someAction()
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
-
-
-### NoFindTaggedServiceIdsCallRule
-
-Instead of "$this->findTaggedServiceIds()" use more reliable registerForAutoconfiguration() and tagged iterator attribute. Those work outside any configuration and avoid missed tag errors
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoFindTaggedServiceIdsCallRule
-```
-
-<br>
-
-### NoRequiredOutsideClassRule
-
-Symfony #[Require]/@required should be used only in classes to avoid misuse
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoRequiredOutsideClassRule
-```
-
-```php
-use Symfony\Component\DependencyInjection\Attribute\Required;
-
-trait SomeTrait
-{
-    #[Required]
-    public function autowireSomeTrait(SomeService $someService)
-    {
-        // ...
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-abstract class SomeClass
-{
-    #[Required]
-    public function autowireSomeClass(SomeService $someService)
-    {
-        // ...
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### SingleArgEventDispatchRule
-
-The event dispatch() method can have only 1 arg - the event object
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\SingleArgEventDispatchRule
-```
-
-```php
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-
-final class SomeClass
-{
-    public function __construct(
-        private EventDispatcherInterface $eventDispatcher
-    ) {
-    }
-
-    public function run()
-    {
-        $this->eventDispatcher->dispatch('event', 'another-arg');
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-
-final class SomeClass
-{
-    public function __construct(
-        private EventDispatcherInterface $eventDispatcher
-    ) {
-    }
-
-    public function run()
-    {
-        $this->eventDispatcher->dispatch(new EventObject());
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoListenerWithoutContractRule
-
-There should be no listeners modified in config. Use EventSubscriberInterface contract and PHP instead
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoListenerWithoutContractRule
-```
-
-```php
-class SomeListener
-{
-    public function onEvent()
-    {
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
-class SomeListener implements EventSubscriberInterface
-{
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            'event' => 'onEvent',
-        ];
-    }
-
-    public function onEvent()
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### NoStringInGetSubscribedEventsRule
-
-Symfony getSubscribedEvents() method must contain only event class references, no strings
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Symfony\NoStringInGetSubscribedEventsRule
-```
-
-```php
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
-class SomeListener implements EventSubscriberInterface
-{
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            'event' => 'onEvent',
-        ];
-    }
-
-    public function onEvent()
-    {
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
-class SomeListener implements EventSubscriberInterface
-{
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            Event::class => 'onEvent',
-        ];
-    }
-
-    public function onEvent()
-    {
-    }
-}
-```
-
-:+1:
-
-<br>
+## 2. Symfony-specific Rules
 
 ### RequireInvokableControllerRule
 
@@ -1761,7 +968,7 @@ Use invokable controller with __invoke() method instead of named action method
 
 ```yaml
 rules:
-    - Symplify\PHPStanRules\Rules\Symfony\RequireInvokableControllerRule
+    - Symplify\PHPStanRules\Symfony\Rules\RequireInvokableControllerRule
 ```
 
 ```php
@@ -1801,37 +1008,25 @@ final class SomeController extends AbstractController
 
 <br>
 
-## 4. PHPUnit-specific Rules
+## 3. PHPUnit-specific Rules
 
-### NoMockObjectAndRealObjectPropertyRule
+### NoTestMocksRule
 
-Avoid using one property for both real object and mock object. Use separate properties or single type instead
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockObjectAndRealObjectPropertyRule
-```
-
-<br>
-
-### NoEntityMockingRule, NoDocumentMockingRule
-
-Instead of entity or document mocking, create object directly to get better type support
+Mocking "%s" class is forbidden. Use direct/anonymous class instead for better static analysis
 
 ```yaml
 rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoEntityMockingRule
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoDocumentMockingRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\NoTestMocksRule
 ```
 
 ```php
 use PHPUnit\Framework\TestCase;
 
-final class SomeTest extends TestCase
+final class SkipApiMock extends TestCase
 {
     public function test()
     {
-        $someEntityMock = $this->createMock(SomeEntity::class);
+        $someTypeMock = $this->createMock(SomeType::class);
     }
 }
 ```
@@ -1843,11 +1038,11 @@ final class SomeTest extends TestCase
 ```php
 use PHPUnit\Framework\TestCase;
 
-final class SomeTest extends TestCase
+final class SkipApiMock extends TestCase
 {
     public function test()
     {
-        $someEntityMock = new SomeEntity();
+        $someTypeMock = new class() implements SomeType {};
     }
 }
 ```
@@ -1855,126 +1050,5 @@ final class SomeTest extends TestCase
 :+1:
 
 <br>
-
-### NoAssertFuncCallInTestsRule
-
-Avoid using assert*() functions in tests, as they can lead to false positives
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoAssertFuncCallInTestsRule
-```
-
-<br>
-
-### NoMockOnlyTestRule
-
-Test should have at least one non-mocked property, to test something
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockOnlyTestRule
-```
-
-```php
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-
-class SomeTest extends TestCase
-{
-    private MockObject $firstMock;
-    private MockObject $secondMock;
-
-    public function setUp()
-    {
-        $this->firstMock = $this->createMock(SomeService::class);
-        $this->secondMock = $this->createMock(AnotherService::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-
-class SomeTest extends TestCase
-{
-    private SomeService $someService;
-
-    private FirstMock $firstMock;
-
-    public function setUp()
-    {
-        $this->someService = new SomeService();
-        $this->firstMock = $this->createMock(AnotherService::class);
-    }
-}
-```
-
-:+1:
-
-<br>
-
-### PublicStaticDataProviderRule
-
-PHPUnit data provider method "%s" must be public
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\PublicStaticDataProviderRule
-```
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SomeTest extends TestCase
-{
-    /**
-     * @dataProvider dataProvider
-     */
-    public function test(): array
-    {
-        return [];
-    }
-
-    protected function dataProvider(): array
-    {
-        return [];
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SomeTest extends TestCase
-{
-    /**
-     * @dataProvider dataProvider
-     */
-    public function test(): array
-    {
-        return [];
-    }
-
-    public static function dataProvider(): array
-    {
-        return [];
-    }
-}
-```
-
-:+1:
-
-<br>
-
 
 Happy coding!


### PR DESCRIPTION
When installing & configuring this package, I found that alot of rules in the README.md file were not found in the `main` branch, so I deleted these rules from the documentation.