### PR TITLE
[doctrine] Fix require call safe `createQueryBuilder` when using DBAL

### DIFF
--- a/src/Enum/DoctrineClass.php
+++ b/src/Enum/DoctrineClass.php
@@ -25,4 +25,9 @@ final class DoctrineClass
      * @var string
      */
     public const ENTITY_REPOSITORY = 'Doctrine\ORM\EntityRepository';
+
+    /**
+     * @var string
+     */
+    public const CONNECTION = 'Doctrine\DBAL\Connection';
 }

--- a/src/Rules/Doctrine/RequireQueryBuilderOnRepositoryRule.php
+++ b/src/Rules/Doctrine/RequireQueryBuilderOnRepositoryRule.php
@@ -52,6 +52,10 @@ final class RequireQueryBuilderOnRepositoryRule implements Rule
             return [];
         }
 
+        if ($callerType->isInstanceOf(DoctrineClass::CONNECTION)->yes()) {
+            return [];
+        }
+
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
             ->identifier(DoctrineRuleIdentifier::REQUIRE_QUERY_BUILDER_ON_REPOSITORY)
             ->build();


### PR DESCRIPTION
Rule "RequireQueryBuilderOnRepositoryRule" requirement not use call `createQueryBuilder('...')` from Entity Manager. But you can be call method  `createQueryBuilder('...')` from DBAL connection (class: `Doctrine\DBAL\Connection`). 

Example: 

```php
<?php

declare(strict_types=1);

namespace App\Query\Examlpe\List;

use Doctrine\DBAL\Connection;

final readonly class Handler
{
    public function __construct(
        private Connection $connection,
    ) {}

    public function __invoke(Query $query): array
    {
        return $this->connection->createQueryBuilder()
            ->select('t.*')
            ->from('table_example', 't')
            ->fetchAllAssociative();
    }
}

```

This is PR fix this when using DBAL.