### PR TITLE
[rector] add PreferDirectIsNameRule

### DIFF
--- a/config/rector-rules.neon
+++ b/config/rector-rules.neon
@@ -5,6 +5,7 @@ rules:
     - Symplify\PHPStanRules\Rules\Rector\NoLeadingBackslashInNameRule
     - Symplify\PHPStanRules\Rules\Rector\NoClassReflectionStaticReflectionRule
     - Symplify\PHPStanRules\Rules\Rector\NoPropertyNodeAssignRule
+    - Symplify\PHPStanRules\Rules\Rector\PreferDirectIsNameRule
 
 services:
     # $node->getAttribute($1) => Type|null by $1

--- a/src/Enum/RuleIdentifier/RectorRuleIdentifier.php
+++ b/src/Enum/RuleIdentifier/RectorRuleIdentifier.php
@@ -15,4 +15,6 @@ final class RectorRuleIdentifier
     public const NO_CLASS_REFLECTION_STATIC_REFLECTION = 'rector.noClassReflectionStaticReflection';
 
     public const NO_PROPERTY_NODE_ASSIGN = 'rector.noPropertyNodeAssign';
+
+    public const PREFER_DIRECT_IS_NAME = 'rector.preferDirectIsName';
 }

--- a/src/Rules/Rector/PreferDirectIsNameRule.php
+++ b/src/Rules/Rector/PreferDirectIsNameRule.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Rector\Rector\AbstractRector;
+use Symplify\PHPStanRules\Enum\RuleIdentifier\RectorRuleIdentifier;
+
+/**
+ * @implements Rule<MethodCall>
+ *
+ * @đee \Symplify\PHPStanRules\Tests\Rules\Rector\PreferDirectIsNameRule\PreferDirectIsNameRuleTest
+ */
+final class PreferDirectIsNameRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Use direct $this->isName() instead of fetching NodeNameResolver service';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isFirstClassCallable()) {
+            return [];
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (! in_array($node->name, ['isName', 'isNames', 'getName'])) {
+            return [];
+        }
+
+        if ($this->shouldSkipClassReflection($scope)) {
+            return [];
+        }
+
+        if (! $node->var instanceof PropertyFetch) {
+            return [];
+        }
+
+        $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+            ->identifier(RectorRuleIdentifier::PREFER_DIRECT_IS_NAME)
+            ->build();
+
+        return [$identifierRuleError];
+    }
+
+    private function shouldSkipClassReflection(Scope $scope): bool
+    {
+        if (! $scope->isInClass()) {
+            return true;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        // skip self
+        if ($classReflection->getName() === AbstractRector::class) {
+            return true;
+        }
+
+        // check rector rules only
+        if (! $classReflection->is(AbstractRector::class)) {
+            return true;
+        }
+
+        // check child Rectors only
+        return $classReflection->isAbstract();
+    }
+}

--- a/tests/Rules/Rector/PreferDirectIsNameRule/Fixture/NonDirectIsName.php
+++ b/tests/Rules/Rector/PreferDirectIsNameRule/Fixture/NonDirectIsName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\PreferDirectIsNameRule\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class NonDirectIsName extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [];
+    }
+
+    public function refactor(Node $node)
+    {
+        $isName = $this->nodeNameResolver->isName($node, 'test');
+    }
+}

--- a/tests/Rules/Rector/PreferDirectIsNameRule/Fixture/SkipDirectIsName.php
+++ b/tests/Rules/Rector/PreferDirectIsNameRule/Fixture/SkipDirectIsName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\PreferDirectIsNameRule\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class SkipDirectIsName extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [];
+    }
+
+    public function refactor(Node $node)
+    {
+        $isName = $this->isName($node, 'test');
+    }
+}

--- a/tests/Rules/Rector/PreferDirectIsNameRule/PreferDirectIsNameRuleTest.php
+++ b/tests/Rules/Rector/PreferDirectIsNameRule/PreferDirectIsNameRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\PreferDirectIsNameRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\Rector\PreferDirectIsNameRule;
+
+final class PreferDirectIsNameRuleTest extends RuleTestCase
+{
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipDirectIsName.php', []];
+
+        yield [__DIR__ . '/Fixture/NonDirectIsName.php', [
+            [
+                PreferDirectIsNameRule::ERROR_MESSAGE,
+                19,
+            ],
+        ]];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new PreferDirectIsNameRule();
+    }
+}

--- a/tests/Rules/Rector/PreferDirectIsNameRule/config/configured_rule.neon
+++ b/tests/Rules/Rector/PreferDirectIsNameRule/config/configured_rule.neon
@@ -1,0 +1,3 @@
+rules:
+    - Symplify\PHPStanRules\Rules\Rector\PreferDirectIsNameRule
+


### PR DESCRIPTION
This rule prefernt calling this in Rector rule:

```php
$this->nodeNameResolver->isName(...);
```

Use helper call instead to avoid directly exposing more services:

```php
$this->isName(...);
```