### PR TITLE
[config] Add FileNameMatchesExtensionRule

### DIFF
--- a/config/symfony-config-rules.neon
+++ b/config/symfony-config-rules.neon
@@ -4,6 +4,9 @@ rules:
     - Symplify\PHPStanRules\Rules\Symfony\ConfigClosure\AlreadyRegisteredAutodiscoveryServiceRule
     - Symplify\PHPStanRules\Rules\Symfony\ConfigClosure\TaggedIteratorOverRepeatedServiceCallRule
 
+    # sync file name and extension name
+    - Symplify\PHPStanRules\Rules\Symfony\ConfigClosure\FileNameMatchesExtensionRule
+
     # no autowire duplicate
     - Symplify\PHPStanRules\Rules\Symfony\NoServiceAutowireDuplicateRule
 

--- a/src/Enum/RuleIdentifier/SymfonyRuleIdentifier.php
+++ b/src/Enum/RuleIdentifier/SymfonyRuleIdentifier.php
@@ -63,4 +63,6 @@ final class SymfonyRuleIdentifier
     public const NO_SET_CLASS_SERVICE_DUPLICATE = 'symfony.noSetClassServiceDuplicate';
 
     public const NO_CONTROLLER_METHOD_INJECTION = 'symfony.noControllerMethodInjection';
+
+    public const FILE_NAME_MATCHES_EXTENSION = 'symfony.fileNameMatchesExtension';
 }

--- a/src/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule.php
+++ b/src/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules\Symfony\ConfigClosure;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeVisitor;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symplify\PHPStanRules\Enum\RuleIdentifier\SymfonyRuleIdentifier;
+use Symplify\PHPStanRules\Symfony\NodeAnalyzer\SymfonyClosureDetector;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\FileNameMatchesExtensionRule\FileNameMatchesExtensionRuleTest
+ * @implements Rule<Closure>
+ */
+final class FileNameMatchesExtensionRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'The config uses "%s" extension, but the file name is "%s". Sync them to ease discovery';
+
+    public function getNodeType(): string
+    {
+        return Closure::class;
+    }
+
+    /**
+     * @param Closure $node
+     * @return IdentifierRuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! SymfonyClosureDetector::detect($node)) {
+            return [];
+        }
+
+        $extensionName = $this->findExtensionName($node);
+        if (! is_string($extensionName)) {
+            return [];
+        }
+
+        // get basefile name
+        $baseFileName = basename($scope->getFile(), '.php');
+        if ($baseFileName === $extensionName) {
+            return [];
+        }
+
+        // find if uses extension and get the name if so
+
+        $identifierRuleError = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $extensionName, $baseFileName))
+            ->identifier(SymfonyRuleIdentifier::FILE_NAME_MATCHES_EXTENSION)
+            ->build();
+
+        return [$identifierRuleError];
+    }
+
+    private function findExtensionName(Closure|Node $node): ?string
+    {
+        $extensionName = null;
+
+        $nodeFinder = new NodeFinder();
+        $nodeFinder->find($node, function (Node $node) use (&$extensionName): ?int {
+            if (! $node instanceof MethodCall) {
+                return null;
+            }
+
+            if (! $node->name instanceof Identifier) {
+                return null;
+            }
+
+            $methodName = $node->name->toString();
+            if ($methodName !== 'extension') {
+                return null;
+            }
+
+            foreach ($node->getArgs() as $arg) {
+                if (! $arg->value instanceof String_) {
+                    continue;
+                }
+
+                $extensionName = $arg->value->value;
+            }
+
+            return NodeVisitor::STOP_TRAVERSAL;
+        });
+
+        return $extensionName;
+    }
+}

--- a/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/FileNameMatchesExtensionRuleTest.php
+++ b/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/FileNameMatchesExtensionRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\FileNameMatchesExtensionRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\Symfony\ConfigClosure\FileNameMatchesExtensionRule;
+
+final class FileNameMatchesExtensionRuleTest extends RuleTestCase
+{
+    /**
+     * @param mixed[] $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/framework.php', []];
+        yield [__DIR__ . '/Fixture/skip_no_extension.php', []];
+
+        yield [__DIR__ . '/Fixture/wrong_name.php', [[
+            sprintf(FileNameMatchesExtensionRule::ERROR_MESSAGE, 'framework', 'wrong_name'),
+            10,
+        ]]];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new FileNameMatchesExtensionRule();
+    }
+}

--- a/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/framework.php
+++ b/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/framework.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Fixture;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\AnotherType;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\SomeServiceWithConstructor;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return function (ContainerConfigurator $container) {
+    $framework = $container->extension('framework');
+};

--- a/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/skip_no_extension.php
+++ b/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/skip_no_extension.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Fixture;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\AnotherType;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\SomeServiceWithConstructor;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return function (ContainerConfigurator $container) {
+    $services = $container->services();;
+};

--- a/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/wrong_name.php
+++ b/tests/Rules/Symfony/ConfigClosure/FileNameMatchesExtensionRule/Fixture/wrong_name.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Fixture;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\AnotherType;
+use Symplify\PHPStanRules\Tests\Rules\Symfony\ConfigClosure\NoDuplicateArgAutowireByTypeRule\Source\SomeServiceWithConstructor;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return function (ContainerConfigurator $container) {
+    $framework = $container->extension('framework');
+};


### PR DESCRIPTION
Sometimes the configs use "framework", but file is named "cache" or "routes" or "config".

Let's sync the name and extension, as they will be grouped by the extension in array config soon :+1: 