### PR TITLE
Fix the code example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2366,7 +2366,7 @@ class SomeTest extends TestCase
 {
     private SomeService $someService;
 
-    private FirstMock $firstMock;
+    private MockObject $firstMock;
 
     public function setUp()
     {


### PR DESCRIPTION
I think there's a typo here.