### PR TITLE
chore: allow webmozart/assert ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "webmozart/assert": "^1.12",
+        "webmozart/assert": "^1.12 || ^2.0",
         "phpstan/phpstan": "^2.1.30",
         "nette/utils": "^4.0",
         "phpstan/phpdoc-parser": "^2.3"


### PR DESCRIPTION
There is no breaking change affecting this project :https://github.com/webmozarts/assert/blob/master/CHANGELOG.md#200


Linked to https://github.com/TomasVotruba/unused-public/pull/153 to have version 2 locally installed because they reference each other.