### PR TITLE
[rules] Add NoMissingVariableDimFetchRule

### DIFF
--- a/config/code-complexity-rules.neon
+++ b/config/code-complexity-rules.neon
@@ -4,3 +4,4 @@ rules:
     - Symplify\PHPStanRules\Rules\Complexity\NoArrayMapWithArrayCallableRule
     - Symplify\PHPStanRules\Rules\Complexity\NoConstructorOverrideRule
     - Symplify\PHPStanRules\Rules\Complexity\ForeachCeptionRule
+    - Symplify\PHPStanRules\Rules\Explicit\NoMissingVariableDimFetchRule

--- a/src/Enum/RuleIdentifier.php
+++ b/src/Enum/RuleIdentifier.php
@@ -77,4 +77,6 @@ final class RuleIdentifier
     public const NO_ARRAY_MAP_WITH_ARRAY_CALLABLE = 'symplify.noArrayMapWithArrayCallable';
 
     public const RULE_IDENTIFIER = 'symplify.foreachCeption';
+
+    public const NO_MISSING_VARIABLE_DIM_FETCH = 'symplify.noMissingVariableDimFetch';
 }

--- a/src/Rules/Explicit/NoMissingVariableDimFetchRule.php
+++ b/src/Rules/Explicit/NoMissingVariableDimFetchRule.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules\Explicit;
+
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Rules\RuleErrorBuilder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanRules\Enum\RuleIdentifier;
+
+/**
+ * @implements Rule<Assign>
+ * @see \Symplify\PHPStanRules\Tests\Rules\Explicit\NoMissingVariableDimFetchRule\NoMissingVariableDimFetchRuleTest
+ */
+final class NoMissingVariableDimFetchRule implements Rule
+{
+    /**
+     * @api
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Dim fetch assign variable is missing, create it first';
+
+    public function getNodeType(): string
+    {
+        return Assign::class;
+    }
+
+    /**
+     * @param Assign $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->var instanceof ArrayDimFetch) {
+            return [];
+        }
+
+        $arrayDimFetch = $node->var;
+        if (! $arrayDimFetch->var instanceof Variable) {
+            return [];
+        }
+
+        $dimFetchVariable = $arrayDimFetch->var;
+
+        if (! is_string($dimFetchVariable->name)) {
+            return [];
+        }
+
+        if (! $scope->hasVariableType($dimFetchVariable->name)->no()) {
+            return [];
+        }
+
+        $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+            ->identifier(RuleIdentifier::NO_MISSING_VARIABLE_DIM_FETCH)
+            ->build();
+
+        return [$identifierRuleError];
+    }
+}

--- a/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/MissingDimFetch.php
+++ b/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/MissingDimFetch.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoMissingVariableDimFetchRule\Fixture;
+
+final class MissingDimFetch
+{
+    public function some()
+    {
+        $dim['key'] = 'value';
+    }
+}

--- a/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/SkipDefinedVariable.php
+++ b/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/SkipDefinedVariable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoMissingVariableDimFetchRule\Fixture;
+
+final class SkipDefinedVariable
+{
+    public function some()
+    {
+        $dim = [];
+        $dim['key'] = 'value';
+    }
+}

--- a/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/SkipProperty.php
+++ b/tests/Rules/Explicit/NoMissingVariableDimFetchRule/Fixture/SkipProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoMissingVariableDimFetchRule\Fixture;
+
+final class SkipProperty
+{
+    private $someProperty = [];
+
+    public function some()
+    {
+        $this->someProperty['key'] = 'value';
+    }
+}

--- a/tests/Rules/Explicit/NoMissingVariableDimFetchRule/NoMissingVariableDimFetchRuleTest.php
+++ b/tests/Rules/Explicit/NoMissingVariableDimFetchRule/NoMissingVariableDimFetchRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoMissingVariableDimFetchRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\Explicit\NoMissingVariableDimFetchRule;
+
+final class NoMissingVariableDimFetchRuleTest extends RuleTestCase
+{
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipDefinedVariable.php', []];
+        yield [__DIR__ . '/Fixture/SkipProperty.php', []];
+
+        yield [__DIR__ . '/Fixture/MissingDimFetch.php', [
+            [NoMissingVariableDimFetchRule::ERROR_MESSAGE, 9],
+        ]];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoMissingVariableDimFetchRule::class);
+    }
+}

--- a/tests/Rules/Explicit/NoMissingVariableDimFetchRule/config/configured_rule.neon
+++ b/tests/Rules/Explicit/NoMissingVariableDimFetchRule/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/included_services.neon
+
+rules:
+    - Symplify\PHPStanRules\Rules\Explicit\NoMissingVariableDimFetchRule


### PR DESCRIPTION
This rule sposts dim fetch assign to a non-existing variable:

```php
class SomeClass
{
    public function some()
    {
        $dim['key'] = 'value';
    }
}
```

<br>

To use it, add it to your `phpstan.neon`:

```yaml
rules:
    - Symplify\PHPStanRules\Rules\Explicit\NoMissingVariableDimFetchRule
```


<br>

Have fun and happy coding :partying_face: 