### PR TITLE
fix: Error in Symplify\PHPStanRules\Rules\NoReferenceRule with #[MapEntity] (fixes symplify/phpstan-rules#263)

### DIFF
--- a/src/ParentClassMethodNodeResolver.php
+++ b/src/ParentClassMethodNodeResolver.php
@@ -23,12 +23,13 @@ final readonly class ParentClassMethodNodeResolver
         $parentClassReflections = $this->getParentClassReflections($scope);
 
         foreach ($parentClassReflections as $parentClassReflection) {
-            if (! $parentClassReflection->hasMethod($methodName)) {
+            // native only: avoid magic methods from extensions (e.g. Doctrine findOneBy*) which can be reported by hasMethod() but throw on getMethod()
+            if (! $parentClassReflection->hasNativeMethod($methodName)) {
                 continue;
             }
 
             $classReflection = $this->reflectionProvider->getClass($parentClassReflection->getName());
-            $parentMethodReflection = $classReflection->getMethod($methodName, $scope);
+            $parentMethodReflection = $classReflection->getNativeMethod($methodName);
             return $this->reflectionParser->parseMethodReflection($parentMethodReflection);
         }
 


### PR DESCRIPTION
## Summary
Fixes symplify/phpstan-rules#263 — Error in Symplify\PHPStanRules\Rules\NoReferenceRule with #[MapEntity]

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.