### PR TITLE
Add NewOverSettersRule ported from tomasvotruba/ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ parameters:
 
 <br>
 
+### NewOverSettersRule
+
+If a class is always created with the same set of setters, pass the values via constructor instead. It makes the object state explicit, safer and easier to test:
+
+```php
+$human = new Human();
+$human->setName('Tomas');
+$human->setAge(35);
+```
+
+:x:
+
+<br>
+
+```php
+$human = new Human(name: 'Tomas', age: 35);
+```
+
+:+1:
+
+<br>
+
+Both `set*` and `add*` method prefixes are treated as setters. The rule is intentionally conservative — it only reports a class instantiated **at least twice** with the same set of setters each time. It skips Doctrine entities, Symfony `Kernel` subclasses, vendor code and `new` + setters blocks interrupted by a `return` or `throw`.
+
+This rule is disabled by default. Enable it with the `ctor` parameter:
+
+```yaml
+parameters:
+    ctor: true
+```
+
+<br>
+
 ### ParamNameToTypeConventionRule
 
 By convention, we can define parameter type by its name. If we know the "userId" is always an `int`, PHPStan can warn us about it and let us know to fill the type.

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "extra": {
         "phpstan": {
             "includes": [
-                "config/services/services.neon"
+                "config/services/services.neon",
+                "config/ctor-rules.neon"
             ]
         }
     }

--- a/config/ctor-rules.neon
+++ b/config/ctor-rules.neon
@@ -1,0 +1,21 @@
+parameters:
+    # enables NewOverSettersRule, disabled by default
+    ctor: false
+
+parametersSchema:
+    ctor: bool()
+
+services:
+    -
+        class: Symplify\PHPStanRules\Collector\NewWithFollowingSettersCollector
+        tags:
+            - phpstan.collector
+        arguments:
+            isEnabled: %ctor%
+
+    -
+        class: Symplify\PHPStanRules\Rules\NewOverSettersRule
+        tags:
+            - phpstan.rules.rule
+        arguments:
+            isEnabled: %ctor%

--- a/src/Collector/NewWithFollowingSettersCollector.php
+++ b/src/Collector/NewWithFollowingSettersCollector.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Collector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\ElseIf_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ReflectionProvider;
+use Symfony\Component\HttpKernel\Kernel;
+use Webmozart\Assert\Assert;
+
+/**
+ * Collect instance of `new`,
+ * which is followed by a method calls on same object
+ *
+ * Goal is to find objects, that are created with same set of setters,
+ * then pass values via constructor instead.
+ *
+ * @implements Collector<Node, array<array{variableName: string, className: string, setterNames: string[]}>>
+ */
+final readonly class NewWithFollowingSettersCollector implements Collector
+{
+    public const string SETTER_NAMES = 'setterNames';
+
+    private const string VARIABLE_NAME = 'variableName';
+
+    /**
+     * @var string[]
+     */
+    private const array EXCLUDED_CLASSES = [Kernel::class];
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private bool $isEnabled
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /**
+     * @return array<array{variableName: string, className: string, setterNames: string[]}>|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        // enable with "ctor: true" parameter
+        if (! $this->isEnabled) {
+            return null;
+        }
+
+        // basically all nodes that have ->stmts inside
+        if (! $node instanceof ClassMethod && ! $node instanceof Function_ && ! $node instanceof If_ && ! $node instanceof ElseIf_ && ! $node instanceof While_ && ! $node instanceof Foreach_ && ! $node instanceof For_) {
+            return null;
+        }
+
+        $newInstancesMetadata = [];
+        $isFlowBrokenInMiddle = false;
+
+        foreach ((array) $node->stmts as $stmt) {
+            // skip iterating if there is a return expression
+            if ($newInstancesMetadata !== [] && $this->isNodeBreakingFlow($stmt)) {
+                $isFlowBrokenInMiddle = true;
+                continue;
+            }
+
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if ($stmt->expr instanceof Assign) {
+                $newInstanceMetadata = $this->matchAssignNewObjectToVariable($stmt);
+                if ($newInstanceMetadata !== null) {
+                    $newInstancesMetadata[] = $newInstanceMetadata;
+                }
+            }
+
+            // waiting for first item, before we check for method calls
+            if ($newInstancesMetadata === []) {
+                continue;
+            }
+
+            if ($stmt->expr instanceof MethodCall) {
+                $methodCall = $stmt->expr;
+
+                if ($methodCall->var instanceof Variable && $methodCall->name instanceof Identifier) {
+                    foreach ($newInstancesMetadata as $key => $newInstanceMetadata) {
+                        if ($newInstanceMetadata[self::VARIABLE_NAME] === $methodCall->var->name) {
+                            // record the method call here
+                            $setterMethodName = $methodCall->name->toString();
+
+                            if (! $this->isSetterName($setterMethodName)) {
+                                continue;
+                            }
+
+                            // skip no-arg setters, the value cannot be moved to the constructor
+                            if ($methodCall->getArgs() === []) {
+                                continue;
+                            }
+
+                            $newInstancesMetadata[$key][self::SETTER_NAMES][] = $setterMethodName;
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($newInstancesMetadata === [] || $isFlowBrokenInMiddle) {
+            return null;
+        }
+
+        return $newInstancesMetadata;
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function shouldSkipClass(string $className): bool
+    {
+        // must be existing class
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return true;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if ($classReflection->getFileName() === null) {
+            return true;
+        }
+
+        // skip excluded classes
+        foreach (self::EXCLUDED_CLASSES as $excludedClass) {
+            if ($classReflection->is($excludedClass)) {
+                return true;
+            }
+        }
+
+        // skip vendor classes
+        if (str_contains($classReflection->getFileName(), 'vendor')) {
+            return true;
+        }
+
+        // skip Doctrine entities
+        $fileContents = file_get_contents($classReflection->getFileName());
+        Assert::string($fileContents);
+
+        return str_contains($fileContents, '@ORM\Entity') || str_starts_with($fileContents, '#[Entity]');
+    }
+
+    /**
+     * @return array{variableName: string, className: string, setterNames: string[]}|null
+     */
+    private function matchAssignNewObjectToVariable(Expression $expression): ?array
+    {
+        if (! $expression->expr instanceof Assign) {
+            return null;
+        }
+
+        $assign = $expression->expr;
+        if (! $assign->expr instanceof New_) {
+            return null;
+        }
+
+        $new = $assign->expr;
+        if (! $new->class instanceof Name) {
+            return null;
+        }
+
+        $assignedVariable = $assign->var;
+        if (! $assignedVariable instanceof Variable) {
+            return null;
+        }
+
+        if (! is_string($assignedVariable->name)) {
+            return null;
+        }
+
+        $variableName = $assignedVariable->name;
+
+        /** @var class-string $className */
+        $className = $new->class->toString();
+        if ($this->shouldSkipClass($className)) {
+            return null;
+        }
+
+        return [
+            self::VARIABLE_NAME => $variableName,
+            'className' => $className,
+            self::SETTER_NAMES => [],
+        ];
+    }
+
+    private function isNodeBreakingFlow(Node $node): bool
+    {
+        $nodeFinder = new NodeFinder();
+
+        return (bool) $nodeFinder->find($node, function (Node $node): bool {
+            if ($node instanceof Return_) {
+                return true;
+            }
+
+            return $node instanceof Throw_;
+        });
+    }
+
+    private function isSetterName(string $setterMethodName): bool
+    {
+        if (str_starts_with($setterMethodName, 'add')) {
+            return true;
+        }
+
+        return str_starts_with($setterMethodName, 'set');
+    }
+}

--- a/src/Enum/RuleIdentifier.php
+++ b/src/Enum/RuleIdentifier.php
@@ -81,4 +81,6 @@ final class RuleIdentifier
     public const string NO_MISSING_VARIABLE_DIM_FETCH = 'symplify.noMissingVariableDimFetch';
 
     public const string NO_MISSNAMED_DOC_TAG = 'symplify.noMissnamedDocTag';
+
+    public const string NEW_OVER_SETTERS = 'symplify.newOverSetters';
 }

--- a/src/Rules/NewOverSettersRule.php
+++ b/src/Rules/NewOverSettersRule.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symplify\PHPStanRules\Collector\NewWithFollowingSettersCollector;
+use Symplify\PHPStanRules\Enum\RuleIdentifier;
+
+/**
+ * @see NewWithFollowingSettersCollector
+ * @see \Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\NewOverSettersRuleTest
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final readonly class NewOverSettersRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Class "%s" is always created with same %d setter(s): "%s()"%sPass these values via constructor instead';
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private bool $isEnabled
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param CollectedDataNode $node
+     * @return IdentifierRuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // enable with "ctor: true" parameter
+        if (! $this->isEnabled) {
+            return [];
+        }
+
+        $collectedDataByFile = $node->get(NewWithFollowingSettersCollector::class);
+
+        // group class + always called setters
+        // if 0 setters, skipp it
+        // if its always the same setters, report it
+
+        $classesToSetterHashes = $this->groupClassesToSetterNames($collectedDataByFile);
+
+        $ruleErrors = [];
+
+        foreach ($classesToSetterHashes as $className => $setterNameGroups) {
+            // we need at least 2 different occurrences to compare
+            if (count($setterNameGroups) === 1) {
+                continue;
+            }
+
+            if (! $this->areAlwaysTheSameMethodNames($setterNameGroups)) {
+                continue;
+            }
+
+            if (! $this->reflectionProvider->hasClass($className)) {
+                continue;
+            }
+
+            $classReflection = $this->reflectionProvider->getClass($className);
+            $setterNameGroup = $setterNameGroups[0];
+
+            $errorMessage = sprintf(
+                self::ERROR_MESSAGE,
+                $className,
+                count($setterNameGroup),
+                implode('()", "', $setterNameGroup),
+                PHP_EOL
+            );
+
+            $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
+                ->identifier(RuleIdentifier::NEW_OVER_SETTERS)
+                ->file((string) $classReflection->getFileName())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @param array<string, list<array<array{variableName: string, className: string, setterNames: string[]}>>> $collectedDataByFile
+     * @return array<string, string[][]>
+     */
+    private function groupClassesToSetterNames(array $collectedDataByFile): array
+    {
+        $classesToSetters = [];
+        foreach ($collectedDataByFile as $collectedData) {
+
+            foreach ($collectedData as $collectedItems) {
+                foreach ($collectedItems as $collectedItem) {
+                    if (count($collectedItem[NewWithFollowingSettersCollector::SETTER_NAMES]) === 0) {
+                        continue;
+                    }
+
+                    $className = $collectedItem['className'];
+
+                    $uniqueSetterNames = array_unique($collectedItem[NewWithFollowingSettersCollector::SETTER_NAMES]);
+                    sort($uniqueSetterNames);
+
+                    $classesToSetters[$className][] = $uniqueSetterNames;
+                }
+            }
+        }
+
+        return $classesToSetters;
+    }
+
+    /**
+     * @param array<string[]> $methodNameGroups
+     */
+    private function areAlwaysTheSameMethodNames(array $methodNameGroups): bool
+    {
+        $methodNameHashes = [];
+        foreach ($methodNameGroups as $methodNameGroup) {
+            $methodNameHashes[] = implode('_', $methodNameGroup);
+        }
+
+        return count(array_unique($methodNameHashes)) === 1;
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/AlwaysSetters.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/AlwaysSetters.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class AlwaysSetters
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(25);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('Doe');
+        $alwaysSetters->setAge(35);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/AlwaysSettersWithDifferentOrder.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/AlwaysSettersWithDifferentOrder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class AlwaysSettersWithDifferentOrder
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(25);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setAge(35);
+        $alwaysSetters->setName('Doe');
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipCalledOnlyOnce.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipCalledOnlyOnce.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class SkipCalledOnlyOnce
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(55);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipDifferentSingleMethod.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipDifferentSingleMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class SkipDifferentSingleMethod
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setAge(25);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipEntity.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeEntity;
+
+final class SkipEntity
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeEntity();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(25);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeEntity();
+        $alwaysSetters->setName('Doe');
+        $alwaysSetters->setAge(35);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipNoArgSetters.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipNoArgSetters.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeTimerObject;
+
+final class SkipNoArgSetters
+{
+    public function first()
+    {
+        $someTimerObject = new SomeTimerObject();
+        $someTimerObject->setStartTime();
+        $someTimerObject->setEndTime();
+    }
+
+    public function second()
+    {
+        $someTimerObject = new SomeTimerObject();
+        $someTimerObject->setStartTime();
+        $someTimerObject->setEndTime();
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipNotSetterCall.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipNotSetterCall.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeEntity;
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeEventDispatcher;
+
+final class SkipNotSetterCall
+{
+    public function first()
+    {
+        $someEventDispatcher = new SomeEventDispatcher();
+        $someEventDispatcher->dispatch('event.name');
+    }
+
+    public function second()
+    {
+        $someEventDispatcher = new SomeEventDispatcher();
+        $someEventDispatcher->dispatch('another.name');
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipOnceThanTwiceMethod.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipOnceThanTwiceMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class SkipOnceThanTwiceMethod
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(55);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setAge(25);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipReturnInMiddle.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipReturnInMiddle.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class SkipReturnInMiddle
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+
+        if (mt_rand(0, 100) > 50) {
+            return;
+        }
+
+        $alwaysSetters->setAge(25);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('Doe');
+        $alwaysSetters->setAge(35);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/SkipSomeKernel.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/SkipSomeKernel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeKernel;
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class SkipSomeKernel
+{
+    public function first()
+    {
+        $someKernel = new SomeKernel();
+        $someKernel->setName('John');
+    }
+
+    public function second()
+    {
+        $someKernel = new SomeKernel();
+        $someKernel->setName('John');
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Fixture/ThreeTimesAlwaysSetters.php
+++ b/tests/Rules/NewOverSettersRule/Fixture/ThreeTimesAlwaysSetters.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class ThreeTimesAlwaysSetters
+{
+    public function first()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('John');
+        $alwaysSetters->setAge(25);
+    }
+
+    public function second()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('Doe');
+        $alwaysSetters->setAge(35);
+    }
+
+    public function thrid()
+    {
+        $alwaysSetters = new SomeObject();
+        $alwaysSetters->setName('Doe');
+        $alwaysSetters->setAge(35);
+    }
+}

--- a/tests/Rules/NewOverSettersRule/NewOverSettersRuleTest.php
+++ b/tests/Rules/NewOverSettersRule/NewOverSettersRuleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule;
+
+use Iterator;
+use Override;
+use PhpParser\Node;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Collector\NewWithFollowingSettersCollector;
+use Symplify\PHPStanRules\Rules\NewOverSettersRule;
+use Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source\SomeObject;
+
+final class NewOverSettersRuleTest extends RuleTestCase
+{
+    /**
+     * @param array<int, array<string|int>> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
+    public static function provideData(): Iterator
+    {
+        $errorMessage = sprintf(
+            NewOverSettersRule::ERROR_MESSAGE,
+            SomeObject::class,
+            2,
+            'setAge()", "setName',
+            PHP_EOL
+        );
+
+        yield [__DIR__ . '/Fixture/AlwaysSetters.php', [[$errorMessage, -1]]];
+        yield [__DIR__ . '/Fixture/AlwaysSettersWithDifferentOrder.php', [[$errorMessage, -1]]];
+        yield [__DIR__ . '/Fixture/ThreeTimesAlwaysSetters.php', [[$errorMessage, -1]]];
+
+        yield [__DIR__ . '/Fixture/SkipDifferentSingleMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipOnceThanTwiceMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipReturnInMiddle.php', []];
+        yield [__DIR__ . '/Fixture/SkipCalledOnlyOnce.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipSomeKernel.php', []];
+        yield [__DIR__ . '/Fixture/SkipEntity.php', []];
+        yield [__DIR__ . '/Fixture/SkipNotSetterCall.php', []];
+        yield [__DIR__ . '/Fixture/SkipNoArgSetters.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NewOverSettersRule::class);
+    }
+
+    /**
+     * @return list<Collector<Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [self::getContainer()->getByType(NewWithFollowingSettersCollector::class)];
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Source/SomeEntity.php
+++ b/tests/Rules/NewOverSettersRule/Source/SomeEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class SomeEntity
+{
+    public function setName(string $name)
+    {
+    }
+
+    public function setAge(int $age)
+    {
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Source/SomeEventDispatcher.php
+++ b/tests/Rules/NewOverSettersRule/Source/SomeEventDispatcher.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source;
+
+final class SomeEventDispatcher
+{
+    public function dispatch(string $evetName): void
+    {
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Source/SomeKernel.php
+++ b/tests/Rules/NewOverSettersRule/Source/SomeKernel.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+final class SomeKernel extends Kernel
+{
+    public function setName(string $name)
+    {
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Source/SomeObject.php
+++ b/tests/Rules/NewOverSettersRule/Source/SomeObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source;
+
+class SomeObject
+{
+    public function setName(string $name)
+    {
+    }
+
+    public function setAge(int $age)
+    {
+    }
+}

--- a/tests/Rules/NewOverSettersRule/Source/SomeTimerObject.php
+++ b/tests/Rules/NewOverSettersRule/Source/SomeTimerObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\NewOverSettersRule\Source;
+
+class SomeTimerObject
+{
+    public function setStartTime()
+    {
+    }
+
+    public function setEndTime()
+    {
+    }
+}

--- a/tests/Rules/NewOverSettersRule/config/configured_rule.neon
+++ b/tests/Rules/NewOverSettersRule/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/ctor-rules.neon
+
+parameters:
+    ctor: true


### PR DESCRIPTION
Merges https://github.com/TomasVotruba/ctor into this package.

## What

* `NewWithFollowingSettersCollector` — collects `new` instances followed by setter calls on the same variable
* `NewOverSettersRule` — reports classes that are **always** created with the same set of setters, suggesting constructor injection instead:

```
Class "App\Human" is always created with same 2 setter(s): "setAge()", "setName()"
Pass these values via constructor instead
```

## How to enable

The rule lives in a separate `config/ctor-rules.neon` config, auto-loaded via extension-installer, and is **disabled by default**. Enable it via parameter:

```yaml
parameters:
    ctor: true
```

## Notes

* Error identifier follows this repo's convention: `symplify.newOverSetters` (was `tv.newOverSetters`)
* Skips Doctrine entities, Symfony `Kernel` subclasses, vendor code, and `new` + setters blocks interrupted by `return`/`throw`
* Tests, fixtures and README docs included; ECS/Rector/PHPStan all green