### PR TITLE
Merge rector/mockstan: PHPUnit mock rules enabled via "mocks: true" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,18 @@ includes:
 
 <br>
 
+Do you use mocks in your PHPUnit tests? Enable mocking rules with single parameter:
+
+```yaml
+parameters:
+    mocks: true
+```
+
+<br>
+
 But at start, make baby steps with one rule at a time:
 
-Jump to: [Symfony-specific rules](#3-symfony-specific-rules), [Doctrine-specific rules](#2-doctrine-specific-rules) or [PHPUnit-specific rules](#4-phpunit-specific-rules).
+Jump to: [Symfony-specific rules](#3-symfony-specific-rules), [Doctrine-specific rules](#2-doctrine-specific-rules), [PHPUnit-specific rules](#4-phpunit-specific-rules) or [PHPUnit mock rules](#5-phpunit-mock-rules).
 
 <br>
 
@@ -2601,59 +2610,6 @@ return function (ContainerConfigurator $container) {
 
 ## 4. PHPUnit-specific Rules
 
-### NoMockObjectAndRealObjectPropertyRule
-
-Avoid using one property for both real object and mock object. Use separate properties or single type instead
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockObjectAndRealObjectPropertyRule
-```
-
-<br>
-
-### NoEntityMockingRule, NoDocumentMockingRule
-
-Instead of entity or document mocking, create object directly to get better type support
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\Doctrine\NoEntityMockingRule
-    - Symplify\PHPStanRules\Rules\Doctrine\NoDocumentMockingRule
-```
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SomeTest extends TestCase
-{
-    public function test()
-    {
-        $someEntityMock = $this->createMock(SomeEntity::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use PHPUnit\Framework\TestCase;
-
-final class SomeTest extends TestCase
-{
-    public function test()
-    {
-        $someEntityMock = new SomeEntity();
-    }
-}
-```
-
-:+1:
-
-<br>
-
 ### NoAssertFuncCallInTestsRule
 
 Avoid using assert*() functions in tests, as they can lead to false positives
@@ -2662,58 +2618,6 @@ Avoid using assert*() functions in tests, as they can lead to false positives
 rules:
     - Symplify\PHPStanRules\Rules\PHPUnit\NoAssertFuncCallInTestsRule
 ```
-
-<br>
-
-### NoMockOnlyTestRule
-
-Test should have at least one non-mocked property, to test something
-
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockOnlyTestRule
-```
-
-```php
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-
-class SomeTest extends TestCase
-{
-    private MockObject $firstMock;
-    private MockObject $secondMock;
-
-    public function setUp()
-    {
-        $this->firstMock = $this->createMock(SomeService::class);
-        $this->secondMock = $this->createMock(AnotherService::class);
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-
-class SomeTest extends TestCase
-{
-    private SomeService $someService;
-
-    private MockObject $firstMock;
-
-    public function setUp()
-    {
-        $this->someService = new SomeService();
-        $this->firstMock = $this->createMock(AnotherService::class);
-    }
-}
-```
-
-:+1:
 
 <br>
 
@@ -2774,14 +2678,141 @@ final class SomeTest extends TestCase
 
 <br>
 
-### ExplicitExpectsMockMethodRule
+## 5. PHPUnit Mock Rules
 
-PHPUnit mock method is missing explicit `expects()`, e.g. `$this->mock->expects($this->once())->...`
+* Do you use extensive mocking in your PHPUnit tests?
+* Do you want to keep your tests clean, maintainable and avoid upgrade hell in the future?
+* Do you want to have tests that actually test something?
+
+This set is for you! Enable all mocking rules with single parameter in your `phpstan.neon`:
 
 ```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\ExplicitExpectsMockMethodRule
+parameters:
+    mocks: true
 ```
+
+<br>
+
+### NoMockOnlyTestRule
+
+Test should have at least one non-mocked property, to test something
+
+```php
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SomeTest extends TestCase
+{
+    private MockObject $firstMock;
+    private MockObject $secondMock;
+
+    public function setUp()
+    {
+        $this->firstMock = $this->createMock(SomeService::class);
+        $this->secondMock = $this->createMock(AnotherService::class);
+    }
+}
+```
+
+:x:
+
+<br>
+
+```php
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SomeTest extends TestCase
+{
+    private SomeService $someService;
+
+    private MockObject $firstMock;
+
+    public function setUp()
+    {
+        $this->someService = new SomeService();
+        $this->firstMock = $this->createMock(AnotherService::class);
+    }
+}
+```
+
+:+1:
+
+<br>
+
+### NoMockObjectAndRealObjectPropertyRule
+
+Avoid using one property for both real object and mock object. Use separate properties or single type instead
+
+```php
+$this->service = $this->createMock(Service::class);
+$this->service = new Service();
+```
+
+:x:
+
+<br>
+
+```php
+$this->someMock = $this->createMock(AnotherService::class);
+
+$this->realService = new Service();
+```
+
+:+1:
+
+<br>
+
+### NoDoubleConsecutiveTestMockRule
+
+Do not use `willReturnOnConsecutiveCalls()` and `willReturnCallback()` on the same mock. Use `willReturnCallback()` only instead to make the test more clear.
+
+```php
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->createMock('SomeClass')
+            ->expects($this->exactly(2))
+            ->method('someMethod')
+            ->willReturnCallback(function () {
+                return 'first';
+            })
+            ->willReturnOnConsecutiveCalls('first');
+    }
+}
+```
+
+:x:
+
+<br>
+
+```php
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->createMock('SomeClass')
+            ->expects($this->exactly(2))
+            ->method('someMethod')
+            ->willReturnCallback(function () {
+                return 'first';
+            });
+    }
+}
+```
+
+:+1:
+
+<br>
+
+### ExplicitExpectsMockMethodRule
+
+PHPUnit mock method is missing explicit `expects()`, e.g. `$this->mock->expects($this->once())->...`. This is required since PHPUnit 12 to avoid silent stubs.
 
 ```php
 use PHPUnit\Framework\TestCase;
@@ -2820,14 +2851,88 @@ final class SomeTest extends TestCase
 
 <br>
 
-### NoDoubleConsecutiveTestMockRule
+### AvoidAnyExpectsRule
 
-Do not use `willReturnOnConsecutiveCalls()` and `willReturnCallback()` on the same mock. Use `willReturnCallback()` only instead to make the test more clear.
+Disallow usage of `any()` expectation in mocks to ensure that all mock interactions are explicitly defined and verified.
 
-```yaml
-rules:
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoDoubleConsecutiveTestMockRule
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->expects($this->any())
+    ->method('calculate')
+    ->willReturn(10);
 ```
+
+:x:
+
+<br>
+
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->expects($this->once())
+    ->method('calculate')
+    ->willReturn(10);
+```
+
+:+1:
+
+<br>
+
+### NoWithOnStubRule
+
+Disallow `with()` on stubs (mocks without `expects()`). PHPUnit deprecates `with()` on test stubs because they silently swallow argument mismatches.
+
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->method('calculate')
+    ->with(10)
+    ->willReturn(20);
+```
+
+:x:
+
+<br>
+
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->expects($this->once())
+    ->method('calculate')
+    ->with(10)
+    ->willReturn(20);
+```
+
+:+1:
+
+<br>
+
+### RequireAtLeastOneRule
+
+Disallow `atLeast(0)` on mock expectations, as it matches any number of calls (including zero) and provides no real verification. Require a value of `1` or higher.
+
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->expects($this->atLeast(0))
+    ->method('calculate')
+    ->willReturn(10);
+```
+
+:x:
+
+<br>
+
+```php
+$someMock = $this->createMock(Service::class);
+$someMock->expects($this->atLeast(1))
+    ->method('calculate')
+    ->willReturn(10);
+```
+
+:+1:
+
+<br>
+
+### NoEntityMockingRule, NoDocumentMockingRule
+
+Instead of entity or document mocking, create object directly to get better type support
 
 ```php
 use PHPUnit\Framework\TestCase;
@@ -2836,13 +2941,7 @@ final class SomeTest extends TestCase
 {
     public function test()
     {
-        $this->createMock('SomeClass')
-            ->expects($this->exactly(2))
-            ->method('someMethod')
-            ->willReturnCallback(function () {
-                return 'first';
-            })
-            ->willReturnOnConsecutiveCalls('first');
+        $someEntityMock = $this->createMock(SomeEntity::class);
     }
 }
 ```
@@ -2858,12 +2957,7 @@ final class SomeTest extends TestCase
 {
     public function test()
     {
-        $this->createMock('SomeClass')
-            ->expects($this->exactly(2))
-            ->method('someMethod')
-            ->willReturnCallback(function () {
-                return 'first';
-            });
+        $someEntityMock = new SomeEntity();
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "phpstan": {
             "includes": [
                 "config/services/services.neon",
-                "config/ctor-rules.neon"
+                "config/ctor-rules.neon",
+                "config/mock-rules.neon"
             ]
         }
     }

--- a/config/mock-rules.neon
+++ b/config/mock-rules.neon
@@ -1,0 +1,48 @@
+# PHPUnit mocking rules, enable in your phpstan.neon with:
+#
+# parameters:
+#     mocks: true
+
+parameters:
+    mocks: false
+
+parametersSchema:
+    mocks: bool()
+
+conditionalTags:
+    # mocking
+    Symplify\PHPStanRules\Rules\PHPUnit\NoMockOnlyTestRule:
+        phpstan.rules.rule: %mocks%
+    Symplify\PHPStanRules\Rules\PHPUnit\NoMockObjectAndRealObjectPropertyRule:
+        phpstan.rules.rule: %mocks%
+
+    # overly complicated
+    Symplify\PHPStanRules\Rules\PHPUnit\NoDoubleConsecutiveTestMockRule:
+        phpstan.rules.rule: %mocks%
+
+    # explicit expects()
+    Symplify\PHPStanRules\Rules\PHPUnit\ExplicitExpectsMockMethodRule:
+        phpstan.rules.rule: %mocks%
+    Symplify\PHPStanRules\Rules\PHPUnit\AvoidAnyExpectsRule:
+        phpstan.rules.rule: %mocks%
+    Symplify\PHPStanRules\Rules\PHPUnit\NoWithOnStubRule:
+        phpstan.rules.rule: %mocks%
+    Symplify\PHPStanRules\Rules\PHPUnit\RequireAtLeastOneRule:
+        phpstan.rules.rule: %mocks%
+
+    # better alternative than mocks
+    Symplify\PHPStanRules\Rules\Doctrine\NoDocumentMockingRule:
+        phpstan.rules.rule: %mocks%
+    Symplify\PHPStanRules\Rules\Doctrine\NoEntityMockingRule:
+        phpstan.rules.rule: %mocks%
+
+services:
+    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockOnlyTestRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockObjectAndRealObjectPropertyRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\NoDoubleConsecutiveTestMockRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\ExplicitExpectsMockMethodRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\AvoidAnyExpectsRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\NoWithOnStubRule
+    - Symplify\PHPStanRules\Rules\PHPUnit\RequireAtLeastOneRule
+    - Symplify\PHPStanRules\Rules\Doctrine\NoDocumentMockingRule
+    - Symplify\PHPStanRules\Rules\Doctrine\NoEntityMockingRule

--- a/config/phpunit-rules.neon
+++ b/config/phpunit-rules.neon
@@ -2,13 +2,7 @@ rules:
     - Symplify\PHPStanRules\Rules\PHPUnit\PublicStaticDataProviderRule
     - Symplify\PHPStanRules\Rules\PHPUnit\NoAssertFuncCallInTestsRule
 
-    # mocking
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockOnlyTestRule
-    - Symplify\PHPStanRules\Rules\Doctrine\NoDocumentMockingRule
-    - Symplify\PHPStanRules\Rules\Doctrine\NoEntityMockingRule
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoMockObjectAndRealObjectPropertyRule
-    - Symplify\PHPStanRules\Rules\PHPUnit\NoDoubleConsecutiveTestMockRule
-
-    # @todo test first
-    # ever method() must have expects() call to define how many times it is expected
-    # - Symplify\PHPStanRules\Rules\PHPUnit\ExplicitExpectsMockMethodRule
+# mocking rules moved to mock-rules.neon, enable them with:
+#
+# parameters:
+#     mocks: true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,5 +15,10 @@
         <exclude>tests/Rules/PHPUnit/NoMockOnlyTestRule/Fixture/SkipConstraintValidatorTest.php</exclude>
         <exclude>tests/Rules/PHPUnit/ExplicitExpectsMockMethodRule/Fixture/SkipMockWithExpectsTest.php</exclude>
         <exclude>tests/Rules/PHPUnit/ExplicitExpectsMockMethodRule/Fixture/MockWithoutExpectsTest.php</exclude>
+        <exclude>tests/Rules/PHPUnit/AvoidAnyExpectsRule/Fixture/SomeAnyTest.php</exclude>
+        <exclude>tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/StubWithWithTest.php</exclude>
+        <exclude>tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/SkipMockWithExpectsAndWithTest.php</exclude>
+        <exclude>tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/AtLeastZeroTest.php</exclude>
+        <exclude>tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/SkipAtLeastOneTest.php</exclude>
     </testsuite>
 </phpunit>

--- a/src/Enum/RuleIdentifier/PHPUnitRuleIdentifier.php
+++ b/src/Enum/RuleIdentifier/PHPUnitRuleIdentifier.php
@@ -17,4 +17,12 @@ final class PHPUnitRuleIdentifier
     public const string NO_ASSERT_FUNC_CALL_IN_TESTS = 'phpunit.noAssertFuncCallInTests';
 
     public const string NO_DOUBLE_CONSECUTIVE_TEST_MOCK = 'phpunit.noDoubleConsecutiveTestMock';
+
+    public const string EXPLICIT_EXPECTS_MOCK_METHOD = 'phpunit.explicitExpectsMockMethod';
+
+    public const string AVOID_ANY_EXPECTS = 'phpunit.avoidAnyExpects';
+
+    public const string NO_WITH_ON_STUB = 'phpunit.noWithOnStub';
+
+    public const string REQUIRE_AT_LEAST_ONE = 'phpunit.requireAtLeastOne';
 }

--- a/src/Rules/PHPUnit/AvoidAnyExpectsRule.php
+++ b/src/Rules/PHPUnit/AvoidAnyExpectsRule.php
@@ -6,8 +6,6 @@ namespace Symplify\PHPStanRules\Rules\PHPUnit;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -19,11 +17,11 @@ use Symplify\PHPStanRules\PHPUnit\TestClassDetector;
 /**
  * @implements Rule<MethodCall>
  *
- * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\ExplicitExpectsMockMethodRule\ExplicitExpectsMockMethodRuleTest
+ * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\AvoidAnyExpectsRule\AvoidAnyExpectsRuleTest
  */
-final class ExplicitExpectsMockMethodRule implements Rule
+final class AvoidAnyExpectsRule implements Rule
 {
-    public const string ERROR_MESSAGE = 'PHPUnit mock method is missing explicit expects(), e.g. $this->mock->expects($this->once())->...';
+    public const string ERROR_MESSAGE = 'Using $this->any() on mock is ambigous. Use explicit count or change to a stub';
 
     public function getNodeType(): string
     {
@@ -36,25 +34,26 @@ final class ExplicitExpectsMockMethodRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! NamingHelper::isName($node->name, 'method')) {
-            return [];
-        }
-
         if (! TestClassDetector::isTestClass($scope)) {
             return [];
         }
 
-        if (! $node->var instanceof Variable && ! $node->var instanceof PropertyFetch) {
+        if (! NamingHelper::isName($node->name, 'expects')) {
             return [];
         }
 
-        $callerType = $scope->getType($node->var);
-        if (! $callerType->hasMethod('expects')->yes()) {
+        $firstArg = $node->getArgs()[0];
+        if (! $firstArg->value instanceof MethodCall) {
+            return [];
+        }
+
+        $nestedCall = $firstArg->value;
+        if (! NamingHelper::isName($nestedCall->name, 'any')) {
             return [];
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(PHPUnitRuleIdentifier::EXPLICIT_EXPECTS_MOCK_METHOD)
+            ->identifier(PHPUnitRuleIdentifier::AVOID_ANY_EXPECTS)
             ->build();
 
         return [$identifierRuleError];

--- a/src/Rules/PHPUnit/NoWithOnStubRule.php
+++ b/src/Rules/PHPUnit/NoWithOnStubRule.php
@@ -19,11 +19,11 @@ use Symplify\PHPStanRules\PHPUnit\TestClassDetector;
 /**
  * @implements Rule<MethodCall>
  *
- * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\ExplicitExpectsMockMethodRule\ExplicitExpectsMockMethodRuleTest
+ * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\NoWithOnStubRule\NoWithOnStubRuleTest
  */
-final class ExplicitExpectsMockMethodRule implements Rule
+final class NoWithOnStubRule implements Rule
 {
-    public const string ERROR_MESSAGE = 'PHPUnit mock method is missing explicit expects(), e.g. $this->mock->expects($this->once())->...';
+    public const string ERROR_MESSAGE = 'Using with() on a stub is misleading and deprecated by PHPUnit. Use explicit expects() to turn it into a mock, or drop with()';
 
     public function getNodeType(): string
     {
@@ -36,7 +36,7 @@ final class ExplicitExpectsMockMethodRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! NamingHelper::isName($node->name, 'method')) {
+        if (! NamingHelper::isName($node->name, 'with')) {
             return [];
         }
 
@@ -44,17 +44,30 @@ final class ExplicitExpectsMockMethodRule implements Rule
             return [];
         }
 
-        if (! $node->var instanceof Variable && ! $node->var instanceof PropertyFetch) {
+        if (! $node->var instanceof MethodCall) {
             return [];
         }
 
-        $callerType = $scope->getType($node->var);
+        $methodCall = $node->var;
+        if (! NamingHelper::isName($methodCall->name, 'method')) {
+            return [];
+        }
+
+        if ($methodCall->var instanceof MethodCall && NamingHelper::isName($methodCall->var->name, 'expects')) {
+            return [];
+        }
+
+        if (! $methodCall->var instanceof Variable && ! $methodCall->var instanceof PropertyFetch) {
+            return [];
+        }
+
+        $callerType = $scope->getType($methodCall->var);
         if (! $callerType->hasMethod('expects')->yes()) {
             return [];
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(PHPUnitRuleIdentifier::EXPLICIT_EXPECTS_MOCK_METHOD)
+            ->identifier(PHPUnitRuleIdentifier::NO_WITH_ON_STUB)
             ->build();
 
         return [$identifierRuleError];

--- a/src/Rules/PHPUnit/RequireAtLeastOneRule.php
+++ b/src/Rules/PHPUnit/RequireAtLeastOneRule.php
@@ -6,8 +6,7 @@ namespace Symplify\PHPStanRules\Rules\PHPUnit;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\Int_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -19,11 +18,11 @@ use Symplify\PHPStanRules\PHPUnit\TestClassDetector;
 /**
  * @implements Rule<MethodCall>
  *
- * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\ExplicitExpectsMockMethodRule\ExplicitExpectsMockMethodRuleTest
+ * @see \Symplify\PHPStanRules\Tests\Rules\PHPUnit\RequireAtLeastOneRule\RequireAtLeastOneRuleTest
  */
-final class ExplicitExpectsMockMethodRule implements Rule
+final class RequireAtLeastOneRule implements Rule
 {
-    public const string ERROR_MESSAGE = 'PHPUnit mock method is missing explicit expects(), e.g. $this->mock->expects($this->once())->...';
+    public const string ERROR_MESSAGE = 'Using $this->atLeast(0) is meaningless, as it matches any number of calls. Use 1 or higher';
 
     public function getNodeType(): string
     {
@@ -36,25 +35,30 @@ final class ExplicitExpectsMockMethodRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! NamingHelper::isName($node->name, 'method')) {
-            return [];
-        }
-
         if (! TestClassDetector::isTestClass($scope)) {
             return [];
         }
 
-        if (! $node->var instanceof Variable && ! $node->var instanceof PropertyFetch) {
+        if (! NamingHelper::isName($node->name, 'atLeast')) {
             return [];
         }
 
-        $callerType = $scope->getType($node->var);
-        if (! $callerType->hasMethod('expects')->yes()) {
+        $args = $node->getArgs();
+        if ($args === []) {
+            return [];
+        }
+
+        $firstArgValue = $args[0]->value;
+        if (! $firstArgValue instanceof Int_) {
+            return [];
+        }
+
+        if ($firstArgValue->value >= 1) {
             return [];
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-            ->identifier(PHPUnitRuleIdentifier::EXPLICIT_EXPECTS_MOCK_METHOD)
+            ->identifier(PHPUnitRuleIdentifier::REQUIRE_AT_LEAST_ONE)
             ->build();
 
         return [$identifierRuleError];

--- a/tests/Rules/PHPUnit/AvoidAnyExpectsRule/AvoidAnyExpectsRuleTest.php
+++ b/tests/Rules/PHPUnit/AvoidAnyExpectsRule/AvoidAnyExpectsRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\AvoidAnyExpectsRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\PHPUnit\AvoidAnyExpectsRule;
+
+final class AvoidAnyExpectsRuleTest extends RuleTestCase
+{
+    /**
+     * @param array<int, array<string|int>> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SomeAnyTest.php', [[AvoidAnyExpectsRule::ERROR_MESSAGE, 13]]];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new AvoidAnyExpectsRule();
+    }
+}

--- a/tests/Rules/PHPUnit/AvoidAnyExpectsRule/Fixture/SomeAnyTest.php
+++ b/tests/Rules/PHPUnit/AvoidAnyExpectsRule/Fixture/SomeAnyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\AvoidAnyExpectsRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeAnyTest extends TestCase
+{
+    public function test(): void
+    {
+        $mock = $this->createMock(\stdClass::class);
+
+        $mock->expects($this->any())
+            ->method('someMethod')
+            ->willReturn('value');
+    }
+}

--- a/tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/SkipMockWithExpectsAndWithTest.php
+++ b/tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/SkipMockWithExpectsAndWithTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\NoWithOnStubRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMockWithExpectsAndWithTest extends TestCase
+{
+    public function test(): void
+    {
+        $mock = $this->createMock(\stdClass::class);
+
+        $mock->expects($this->once())
+            ->method('someMethod')
+            ->with('arg')
+            ->willReturn('value');
+    }
+}

--- a/tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/StubWithWithTest.php
+++ b/tests/Rules/PHPUnit/NoWithOnStubRule/Fixture/StubWithWithTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\NoWithOnStubRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class StubWithWithTest extends TestCase
+{
+    public function test(): void
+    {
+        $mock = $this->createMock(\stdClass::class);
+
+        $mock->method('someMethod')
+            ->with('arg')
+            ->willReturn('value');
+    }
+}

--- a/tests/Rules/PHPUnit/NoWithOnStubRule/NoWithOnStubRuleTest.php
+++ b/tests/Rules/PHPUnit/NoWithOnStubRule/NoWithOnStubRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\NoWithOnStubRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\PHPUnit\NoWithOnStubRule;
+
+final class NoWithOnStubRuleTest extends RuleTestCase
+{
+    /**
+     * @param array<int, array<string|int>> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/StubWithWithTest.php', [[NoWithOnStubRule::ERROR_MESSAGE, 13]]];
+
+        yield [__DIR__ . '/Fixture/SkipMockWithExpectsAndWithTest.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoWithOnStubRule();
+    }
+}

--- a/tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/AtLeastZeroTest.php
+++ b/tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/AtLeastZeroTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\RequireAtLeastOneRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class AtLeastZeroTest extends TestCase
+{
+    public function test(): void
+    {
+        $mock = $this->createMock(\stdClass::class);
+
+        $mock->expects($this->atLeast(0))
+            ->method('someMethod')
+            ->willReturn('value');
+    }
+}

--- a/tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/SkipAtLeastOneTest.php
+++ b/tests/Rules/PHPUnit/RequireAtLeastOneRule/Fixture/SkipAtLeastOneTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\RequireAtLeastOneRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipAtLeastOneTest extends TestCase
+{
+    public function test(): void
+    {
+        $mock = $this->createMock(\stdClass::class);
+
+        $mock->expects($this->atLeast(1))
+            ->method('someMethod')
+            ->willReturn('value');
+
+        $anotherMock = $this->createMock(\stdClass::class);
+        $anotherMock->expects($this->atLeast(3))
+            ->method('anotherMethod')
+            ->willReturn('value');
+    }
+}

--- a/tests/Rules/PHPUnit/RequireAtLeastOneRule/RequireAtLeastOneRuleTest.php
+++ b/tests/Rules/PHPUnit/RequireAtLeastOneRule/RequireAtLeastOneRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\PHPUnit\RequireAtLeastOneRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\Rules\PHPUnit\RequireAtLeastOneRule;
+
+final class RequireAtLeastOneRuleTest extends RuleTestCase
+{
+    /**
+     * @param array<int, array<string|int>> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/AtLeastZeroTest.php', [[RequireAtLeastOneRule::ERROR_MESSAGE, 13]]];
+        yield [__DIR__ . '/Fixture/SkipAtLeastOneTest.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new RequireAtLeastOneRule();
+    }
+}


### PR DESCRIPTION
Merges [rector/mockstan](https://github.com/rectorphp/mockstan) into this package.

## What's new

* Ported 3 rules from mockstan that were missing here, with tests:
  * `AvoidAnyExpectsRule` — disallow ambiguous `expects($this->any())`
  * `NoWithOnStubRule` — disallow `with()` on stubs without `expects()`
  * `RequireAtLeastOneRule` — disallow meaningless `atLeast(0)`

* New `config/mock-rules.neon` with **all** mocking rules (the 3 new ones + `NoMockOnlyTestRule`, `NoMockObjectAndRealObjectPropertyRule`, `NoDoubleConsecutiveTestMockRule`, `ExplicitExpectsMockMethodRule`, `NoDocumentMockingRule`, `NoEntityMockingRule`). The config is auto-loaded via `phpstan/extension-installer` and the rules are enabled with a single parameter:

```yaml
parameters:
    mocks: true
```

## Changes

* mocking rules moved out of `config/phpunit-rules.neon` into `config/mock-rules.neon`, gated behind the `mocks` parameter via `conditionalTags`
* `ExplicitExpectsMockMethodRule` now reports its own `phpunit.explicitExpectsMockMethod` identifier (was copy-pasted `phpunit.noAssertFuncCallInTests`)
* README: new "PHPUnit Mock Rules" section documenting the parameter and all rules

## Not ported

* `ForbiddenClassToMockRule` — already covered by existing `NoTestMocksRule`
* rules that already existed here kept their local implementation