### PR TITLE
Merge symplify/phpstan-extenisons here, as only few classes

### DIFF
--- a/.github/workflows/bare_run.yaml
+++ b/.github/workflows/bare_run.yaml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.4', '8.0', '8.2']
+                php_version: ['7.4', '8.0', '8.2', '8.4']
 
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -38,7 +38,7 @@ jobs:
 
                     -
                         name: 'Check Active Classes'
-                        run: vendor/bin/class-leak check src --ansi
+                        run: vendor/bin/class-leak check src --ansi --skip-type "PHPStan\Type\DynamicMethodReturnTypeExtension" --skip-type "PHPStan\Type\DynamicFunctionReturnTypeExtension"
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2966,4 +2966,51 @@ final class SomeTest extends TestCase
 
 <br>
 
+## 6. Type Extensions and Error Formatter
+
+These extensions were merged from the now-deprecated [`symplify/phpstan-extensions`](https://github.com/symplify/phpstan-extensions)
+package. They load automatically once `phpstan/extension-installer` is set up - no extra
+configuration is needed.
+
+<br>
+
+### `symplify` Error Formatter
+
+A compact error format with pre-escaped, regex-ready messages that are easy to copy into
+your `ignoreErrors` list. File paths are printed with line numbers and stay clickable in
+the terminal (works best with [anthraxx/intellij-awesome-console](https://github.com/anthraxx/intellij-awesome-console)).
+
+Enable it in your `phpstan.neon`:
+
+```yaml
+parameters:
+    errorFormat: symplify
+```
+
+or on the command line:
+
+```bash
+vendor/bin/phpstan analyse --error-format symplify
+```
+
+<br>
+
+### Type Extensions
+
+Always-on return type extensions that sharpen PHPStan inference for common framework calls:
+
+* **`ContainerGetReturnTypeExtension`** - `$container->get(SomeService::class)` returns
+  `SomeService` instead of plain `object` (Symfony `ContainerInterface`).
+
+* **`LaravelContainerMakeTypeExtension`** - `$container->make(SomeService::class)` and
+  `->get(SomeService::class)` return `SomeService` (Laravel `Illuminate\Container\Container`).
+
+* **`SplFileInfoTolerantReturnTypeExtension`** - `$splFileInfo->getRealPath()` returns
+  `string` instead of `string|false`, as Symfony Finder only yields existing files.
+
+* **`NativeFunctionReturnTypeExtension`** - `getcwd()`, `dirname()` and `realpath()` return
+  `string` instead of `string|false`.
+
+<br>
+
 Happy coding!

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ parameters:
 
 <br>
 
+Want sharper type inference for service containers? The Symfony and Laravel return type extensions are **disabled by default** — enable the ones that fit your stack:
+
+```yaml
+parameters:
+    symfonyReturnType: true
+    laravelReturnType: true
+```
+
+`symfonyReturnType` resolves `$container->get(SomeService::class)` to `SomeService` and Symfony Finder's `$splFileInfo->getRealPath()` to `string`. `laravelReturnType` does the same for Laravel's `$container->make(SomeService::class)`:
+
+```php
+$service = $container->get(SomeService::class);
+// $service is now known as SomeService, instead of plain object
+```
+
+<br>
+
 But at start, make baby steps with one rule at a time:
 
 Jump to: [Symfony-specific rules](#3-symfony-specific-rules), [Doctrine-specific rules](#2-doctrine-specific-rules), [PHPUnit-specific rules](#4-phpunit-specific-rules) or [PHPUnit mock rules](#5-phpunit-mock-rules).

--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ parameters:
 
 <br>
 
-Want sharper type inference for service containers? The Symfony and Laravel return type extensions are **disabled by default** — enable the ones that fit your stack:
+Want sharper type inference? The return type extensions are **disabled by default** — enable the ones that fit your stack:
 
 ```yaml
 parameters:
     symfonyReturnType: true
     laravelReturnType: true
+    pathStrings: true
 ```
 
-`symfonyReturnType` resolves `$container->get(SomeService::class)` to `SomeService` and Symfony Finder's `$splFileInfo->getRealPath()` to `string`. `laravelReturnType` does the same for Laravel's `$container->make(SomeService::class)`:
+`symfonyReturnType` resolves `$container->get(SomeService::class)` to `SomeService` and Symfony Finder's `$splFileInfo->getRealPath()` to `string`. `laravelReturnType` does the same for Laravel's `$container->make(SomeService::class)`. `pathStrings` narrows `getcwd()`, `dirname()` and `realpath()` to `string`:
 
 ```php
 $service = $container->get(SomeService::class);

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -14,6 +14,15 @@ return new Configuration()
     // optional classes
     ->ignoreUnknownClasses(['Symfony\Component\ExpressionLanguage\Expression'])
 
+    // windows-only function used in Terminal helper
+    ->ignoreUnknownFunctions(['sapi_windows_vt100_support'])
+
+    // used only by the Symfony Finder SplFileInfo return type extension
+    ->ignoreErrorsOnPackage('symfony/finder', [ErrorType::SHADOW_DEPENDENCY])
+
+    // extension that runs on Laravel Container only
+    ->ignoreErrorsOnPackage('illuminate/container', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+
     // already in phpstan/phpstan
     ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPackage('symfony/routing', [ErrorType::SHADOW_DEPENDENCY])

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Set of Symplify rules for PHPStan",
     "license": "MIT",
     "require": {
-        "php": ">=8.4",
-        "webmozart/assert": " ^2.0",
+        "php": "^8.4",
+        "webmozart/assert": "^2.0",
         "phpstan/phpstan": "^2.2",
         "nette/utils": "^4.1",
         "phpstan/phpdoc-parser": "^2.3"

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         "nikic/php-parser": "^5.7",
         "phpunit/phpunit": "^13.0",
         "symfony/framework-bundle": "^6.2",
-        "symplify/easy-coding-standard": "^13.0",
+        "illuminate/container": "^11.0",
+        "phpecs/phpecs": "^2.2",
         "tomasvotruba/class-leak": "^2.1",
         "rector/rector": "^2.4",
         "phpstan/extension-installer": "^1.4",
-        "symplify/phpstan-extensions": "^12.0",
         "tomasvotruba/unused-public": "^2.2",
         "tomasvotruba/type-coverage": "^2.2",
         "shipmonk/composer-dependency-analyser": "^1.8",
@@ -61,7 +61,8 @@
             "includes": [
                 "config/services/services.neon",
                 "config/ctor-rules.neon",
-                "config/mock-rules.neon"
+                "config/mock-rules.neon",
+                "config/phpstan-extensions.neon"
             ]
         }
     }

--- a/config/phpstan-extensions.neon
+++ b/config/phpstan-extensions.neon
@@ -7,17 +7,17 @@ services:
 
     # Symfony Container::get($1) => $1 type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
     # Laravel Container::make($1) => $1 type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
     # Symfony Finder SplFileInfo::getRealPath() => string type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
     # getcwd()/dirname()/realpath() => always "string"

--- a/config/phpstan-extensions.neon
+++ b/config/phpstan-extensions.neon
@@ -1,16 +1,19 @@
-# Symfony/Laravel return type extensions are disabled by default; enable in your phpstan.neon with:
+# return type extensions are disabled by default; enable in your phpstan.neon with:
 #
 # parameters:
 #     symfonyReturnType: true
 #     laravelReturnType: true
+#     pathStrings: true
 
 parameters:
     symfonyReturnType: false
     laravelReturnType: false
+    pathStrings: false
 
 parametersSchema:
     symfonyReturnType: bool()
     laravelReturnType: bool()
+    pathStrings: bool()
 
 conditionalTags:
     # Symfony Container::get($1) => $1 type
@@ -22,6 +25,9 @@ conditionalTags:
     # Laravel Container::make($1) => $1 type
     Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension:
         phpstan.broker.dynamicMethodReturnTypeExtension: %laravelReturnType%
+    # getcwd()/dirname()/realpath() => always "string"
+    Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension:
+        phpstan.broker.dynamicFunctionReturnTypeExtension: %pathStrings%
 
 services:
     # use with "errorFormat: symplify" in CLI/config
@@ -31,8 +37,4 @@ services:
     - Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
     - Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
     - Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
-
-    # getcwd()/dirname()/realpath() => always "string"
-    -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension
-        tags: [phpstan.broker.dynamicFunctionReturnTypeExtension]
+    - Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension

--- a/config/phpstan-extensions.neon
+++ b/config/phpstan-extensions.neon
@@ -1,0 +1,26 @@
+services:
+    # use with "errorFormat: symplify" in CLI/config
+    errorFormatter.symplify:
+        class: Symplify\PHPStanRules\ErrorFormatter\SymplifyErrorFormatter
+
+    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
+
+    # Symfony Container::get($1) => $1 type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+    # Laravel Container::make($1) => $1 type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+    # Symfony Finder SplFileInfo::getRealPath() => string type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+    # getcwd()/dirname()/realpath() => always "string"
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension
+        tags: [phpstan.broker.dynamicFunctionReturnTypeExtension]

--- a/config/phpstan-extensions.neon
+++ b/config/phpstan-extensions.neon
@@ -1,24 +1,36 @@
+# Symfony/Laravel return type extensions are disabled by default; enable in your phpstan.neon with:
+#
+# parameters:
+#     symfonyReturnType: true
+#     laravelReturnType: true
+
+parameters:
+    symfonyReturnType: false
+    laravelReturnType: false
+
+parametersSchema:
+    symfonyReturnType: bool()
+    laravelReturnType: bool()
+
+conditionalTags:
+    # Symfony Container::get($1) => $1 type
+    Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension:
+        phpstan.broker.dynamicMethodReturnTypeExtension: %symfonyReturnType%
+    # Symfony Finder SplFileInfo::getRealPath() => string type
+    Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension:
+        phpstan.broker.dynamicMethodReturnTypeExtension: %symfonyReturnType%
+    # Laravel Container::make($1) => $1 type
+    Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension:
+        phpstan.broker.dynamicMethodReturnTypeExtension: %laravelReturnType%
+
 services:
     # use with "errorFormat: symplify" in CLI/config
     errorFormatter.symplify:
         class: Symplify\PHPStanRules\ErrorFormatter\SymplifyErrorFormatter
 
-    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
-
-    # Symfony Container::get($1) => $1 type
-    -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
-        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
-
-    # Laravel Container::make($1) => $1 type
-    -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
-        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
-
-    # Symfony Finder SplFileInfo::getRealPath() => string type
-    -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
-        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    - Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
+    - Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
+    - Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
 
     # getcwd()/dirname()/realpath() => always "string"
     -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     - config/services/services.neon
     - config/naming-rules.neon
+    - config/phpstan-extensions.neon
 
 parameters:
     treatPhpDocTypesAsCertain: false
@@ -46,7 +47,12 @@ parameters:
 
         -
             message: '#Generator expects value type array<string, mixed>, list<bool\|float\|int\|list<string>\|PHPStan\\TrinaryLogic\|string\|null> given#'
-            path: tests/ReturnTypeExtension/NodeGetAttributeTypeExtension/NodeGetAttributeTypeExtensionTest.php
+            path: tests/ReturnTypeExtension/*
+
+        # PHPStan testing helper, intentionally extended
+        -
+            message: '#is not covered by backward compatibility promise#'
+            path: tests/ErrorFormatter/SymplifyErrorFormatterTest.php
 
         - '#Although PHPStan\\Node\\InClassNode is covered by backward compatibility promise, this instanceof assumption might break because (.*?) not guaranteed to always stay the same#'
         - '#PHPStan\\DependencyInjection\\NeonAdapter#'

--- a/src/Console/Terminal.php
+++ b/src/Console/Terminal.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Console;
+
+/**
+ * Copied mostly from symfony/console, to avoid hard dependency for single method
+ * @see https://github.com/symfony/symfony/blob/e16aea4e88bfecec4986bf7a693f84a86c074109/src/Symfony/Component/Console/Terminal.php#L86
+ */
+final class Terminal
+{
+    /**
+     * @var array<int, array<string>>
+     */
+    private const array DESCRIPTORSPEC = [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    private static ?int $width = null;
+
+    private static ?bool $stty = null;
+
+    public static function getWidth(): int
+    {
+        $width = \getenv('COLUMNS');
+        if ($width !== \false) {
+            return (int) \trim($width);
+        }
+
+        if (self::$width === null) {
+            self::initDimensions();
+        }
+
+        return self::$width ?: 80;
+    }
+
+    private static function hasSttyAvailable(): bool
+    {
+        if (self::$stty !== null) {
+            return self::$stty;
+        }
+
+        if (! \function_exists('exec')) {
+            return \false;
+        }
+
+        \exec('stty 2>&1', $output, $exitcode);
+        return self::$stty = $exitcode === 0;
+    }
+
+    private static function initDimensions(): void
+    {
+        $consoleMode = self::getConsoleMode();
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $width = self::getAnsiconWidth();
+            if ($width !== null) {
+                self::$width = $width;
+            } elseif (! self::hasVt100Support() && self::hasSttyAvailable()) {
+                self::initDimensionsUsingStty();
+            } elseif ($consoleMode) {
+                self::$width = $consoleMode[0];
+            }
+        } else {
+            self::initDimensionsUsingStty();
+        }
+    }
+
+    private static function hasVt100Support(): bool
+    {
+        if (! \function_exists('sapi_windows_vt100_support')) {
+            return \false;
+        }
+
+        $stdoutStream = \fopen('php://stdout', 'w');
+        if ($stdoutStream === \false) {
+            return \false;
+        }
+
+        return \sapi_windows_vt100_support($stdoutStream);
+    }
+
+    private static function initDimensionsUsingStty(): void
+    {
+        $sttyColumns = self::getSttyColumns();
+
+        if ($sttyColumns) {
+            if (\preg_match('#rows.(\d+);.columns.(\d+);#i', $sttyColumns, $matches)) {
+                self::$width = (int) $matches[2];
+            } elseif (\preg_match('#;.(\d+).rows;.(\d+).columns#i', $sttyColumns, $matches)) {
+                self::$width = (int) $matches[2];
+            }
+        }
+    }
+
+    /**
+     * @return array{0: int, 1: int}|null
+     */
+    private static function getConsoleMode(): ?array
+    {
+        $info = self::readFromProcess('mode CON');
+        if ($info === null) {
+            return null;
+        }
+
+        if (! \preg_match('#--------+\r?\n.+?(\d+)\r?\n.+?(\d+)\r?\n#', $info, $matches)) {
+            return null;
+        }
+
+        return [(int) $matches[2], (int) $matches[1]];
+    }
+
+    private static function getSttyColumns(): ?string
+    {
+        return self::readFromProcess('stty -a | grep columns');
+    }
+
+    private static function readFromProcess(string $command): ?string
+    {
+        if (! \function_exists('proc_open')) {
+            return null;
+        }
+
+        $process = \proc_open($command, self::DESCRIPTORSPEC, $pipes, null, null, [
+            'suppress_errors' => \true,
+        ]);
+        if (! \is_resource($process)) {
+            return null;
+        }
+
+        $info = \stream_get_contents($pipes[1]);
+        \fclose($pipes[1]);
+        \fclose($pipes[2]);
+        \proc_close($process);
+        return $info;
+    }
+
+    private static function getAnsiconWidth(): ?int
+    {
+        $ansicon = \getenv('ANSICON');
+        if (! is_string($ansicon)) {
+            return null;
+        }
+
+        if (\preg_match('#^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$#', \trim($ansicon), $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Enum/ResultStatus.php
+++ b/src/Enum/ResultStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Enum;
+
+final class ResultStatus
+{
+    public const int SUCCESS = 0;
+
+    public const int FAILURE = 1;
+}

--- a/src/ErrorFormatter/SymplifyErrorFormatter.php
+++ b/src/ErrorFormatter/SymplifyErrorFormatter.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ErrorFormatter;
+
+use PHPStan\Analyser\Error;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
+use PHPStan\Command\Output;
+use PHPStan\Command\OutputStyle;
+use Symplify\PHPStanRules\Console\Terminal;
+use Symplify\PHPStanRules\Enum\ResultStatus;
+use Symplify\PHPStanRules\FileSystem\FilesystemHelper;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\ErrorFormatter\SymplifyErrorFormatterTest
+ */
+final class SymplifyErrorFormatter implements ErrorFormatter
+{
+    /**
+     * To fit in Linux/Windows terminal windows to prevent overflow.
+     */
+    private const int BULGARIAN_CONSTANT = 8;
+
+    /**
+     * @see https://regex101.com/r/1ghDuM/1
+     */
+    private const string FILE_WITH_TRAIT_CONTEXT_REGEX = '#(?<file>.*?)(\s+\(in context.*?)?$#';
+
+    private ?Output $output = null;
+
+    /**
+     * @return ResultStatus::*
+     */
+    public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+    {
+        $outputStyle = $output->getStyle();
+        $this->output = $output;
+
+        if ($analysisResult->getTotalErrorsCount() === 0 && $analysisResult->getWarnings() === []) {
+            $outputStyle->success('No errors');
+            return ResultStatus::SUCCESS;
+        }
+
+        $this->reportErrors($analysisResult, $outputStyle);
+
+        $notFileSpecificErrors = $analysisResult->getNotFileSpecificErrors();
+        foreach ($notFileSpecificErrors as $notFileSpecificError) {
+            $outputStyle->warning($notFileSpecificError);
+        }
+
+        $warnings = $analysisResult->getWarnings();
+        foreach ($warnings as $warning) {
+            $outputStyle->warning($warning);
+        }
+
+        return ResultStatus::FAILURE;
+    }
+
+    private function reportErrors(AnalysisResult $analysisResult, OutputStyle $outputStyle): void
+    {
+        if ($analysisResult->getFileSpecificErrors() === []) {
+            return;
+        }
+
+        foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+            $this->printSingleError($fileSpecificError, $outputStyle);
+        }
+
+        $outputStyle->newLine();
+
+        $errorMessage = sprintf('Found %d errors', $analysisResult->getTotalErrorsCount());
+        $outputStyle->error($errorMessage);
+    }
+
+    private function separator(): void
+    {
+        $separator = str_repeat('-', Terminal::getWidth() - self::BULGARIAN_CONSTANT);
+        $this->writeln($separator);
+    }
+
+    private function getRelativePath(string $filePath): string
+    {
+        // remove trait clutter
+        /** @var string $clearFilePath */
+        $clearFilePath = preg_replace(self::FILE_WITH_TRAIT_CONTEXT_REGEX, '$1', $filePath);
+
+        if (! file_exists($clearFilePath)) {
+            return $clearFilePath;
+        }
+
+        return FilesystemHelper::resolveFromCwd($clearFilePath);
+    }
+
+    private function regexMessage(string $message): string
+    {
+        // remove extra ".", that is really not part of message
+        $message = rtrim($message, '.');
+        return '#' . preg_quote($message, '#') . '#';
+    }
+
+    private function writeln(string $separator): void
+    {
+        $this->output?->writeLineFormatted(' ' . $separator);
+    }
+
+    private function printSingleError(Error $error, OutputStyle $outputStyle): void
+    {
+        $this->separator();
+
+        $relativeFilePath = $this->getRelativePath($error->getFile());
+        $relativeLine = $relativeFilePath . ':' . $error->getLine();
+
+        // template error
+        $templateFilePath = $error->getMetadata()['template_file_path'] ?? null;
+        $templateLine = $error->getMetadata()['template_line'] ?? null;
+
+        if ($templateFilePath && $templateLine) {
+            $templateFileLine = $this->getRelativePath($templateFilePath) . ':' . $templateLine;
+            $this->writeln($templateFileLine);
+
+            $this->writeln('rendered in: ' . $relativeLine);
+            $this->separator();
+        } else {
+            // clickable path
+            $this->writeln(' ' . $relativeLine);
+            $this->separator();
+        }
+
+        // ignored path - @todo include file
+        $regexMessage = $this->regexMessage($error->getMessage());
+        $itemMessage = sprintf(" - '%s'", $regexMessage);
+        $this->writeln($itemMessage);
+
+        if ($error->getIdentifier() !== null && $error->canBeIgnored()) {
+            $this->writeln(' 🪪 ' . $error->getIdentifier());
+        }
+
+        $this->separator();
+        $outputStyle->newLine();
+    }
+}

--- a/src/FileSystem/FilesystemHelper.php
+++ b/src/FileSystem/FilesystemHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\FileSystem;
+
+final class FilesystemHelper
+{
+    public static function resolveFromCwd(string $filePath): string
+    {
+        // make path relative with native PHP
+        $realPath = (string) realpath($filePath);
+        $relativeFilePath = str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $realPath);
+
+        return rtrim($relativeFilePath, '/');
+    }
+}

--- a/src/ReturnTypeExtension/ContainerGetReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/ContainerGetReturnTypeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ReturnTypeExtension;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver;
+
+/**
+ * @inspiration https://github.com/phpstan/phpstan-symfony/blob/master/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
+ *
+ * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\ContainerGetReturnTypeExtension\ContainerGetReturnTypeExtensionTest
+ */
+final readonly class ContainerGetReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(
+        private ClassConstFetchReturnTypeResolver $classConstFetchReturnTypeResolver
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return ContainerInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
+    }
+}

--- a/src/ReturnTypeExtension/Laravel/LaravelContainerMakeTypeExtension.php
+++ b/src/ReturnTypeExtension/Laravel/LaravelContainerMakeTypeExtension.php
@@ -17,13 +17,8 @@ use Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver;
  *
  * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\LaravelContainerMakeTypeExtension\LaravelContainerMakeTypeExtensionTest
  */
-final readonly class LaravelContainerMakeTypeExtension implements DynamicMethodReturnTypeExtension
+final class LaravelContainerMakeTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    public function __construct(
-        private ClassConstFetchReturnTypeResolver $classConstFetchReturnTypeResolver
-    ) {
-    }
-
     public function getClass(): string
     {
         return Container::class;
@@ -39,6 +34,6 @@ final readonly class LaravelContainerMakeTypeExtension implements DynamicMethodR
         MethodCall $methodCall,
         Scope $scope
     ): ?Type {
-        return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
+        return ClassConstFetchReturnTypeResolver::resolve($methodReflection, $methodCall);
     }
 }

--- a/src/ReturnTypeExtension/Laravel/LaravelContainerMakeTypeExtension.php
+++ b/src/ReturnTypeExtension/Laravel/LaravelContainerMakeTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\ReturnTypeExtension;
+namespace Symplify\PHPStanRules\ReturnTypeExtension\Laravel;
 
 use Illuminate\Container\Container;
 use PhpParser\Node\Expr\MethodCall;

--- a/src/ReturnTypeExtension/LaravelContainerMakeTypeExtension.php
+++ b/src/ReturnTypeExtension/LaravelContainerMakeTypeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ReturnTypeExtension;
+
+use Illuminate\Container\Container;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver;
+
+/**
+ * Helps to check Container->make() return type
+ *
+ * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\LaravelContainerMakeTypeExtension\LaravelContainerMakeTypeExtensionTest
+ */
+final readonly class LaravelContainerMakeTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(
+        private ClassConstFetchReturnTypeResolver $classConstFetchReturnTypeResolver
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return Container::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['make', 'get'], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
+    }
+}

--- a/src/ReturnTypeExtension/NativeFunctionReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/NativeFunctionReturnTypeExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ReturnTypeExtension;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\NativeFunctionReturnTypeExtension\NativeFunctionReturnTypeExtensionTest
+ */
+final class NativeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array($functionReflection->getName(), ['getcwd', 'dirname', 'realpath'], true);
+    }
+
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $funcCall,
+        Scope $scope
+    ): Type {
+        return new StringType();
+    }
+}

--- a/src/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ReturnTypeExtension;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Symfony provided Symfony\Component\Finder\SplFileInfo always exists, so checking every single
+ * $splFileInfo->getRealPath() has no added value. Just pollutes code and config and makes it unreadable.
+ *
+ * This narrows validation only to custom created SplFileInfo.
+ *
+ * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension\SplFileInfoTolerantReturnTypeExtensionTest
+ */
+final class SplFileInfoTolerantReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return SplFileInfo::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getRealPath';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        return new StringType();
+    }
+}

--- a/src/ReturnTypeExtension/Symfony/ContainerGetReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/Symfony/ContainerGetReturnTypeExtension.php
@@ -17,13 +17,8 @@ use Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver;
  *
  * @see \Symplify\PHPStanRules\Tests\ReturnTypeExtension\ContainerGetReturnTypeExtension\ContainerGetReturnTypeExtensionTest
  */
-final readonly class ContainerGetReturnTypeExtension implements DynamicMethodReturnTypeExtension
+final class ContainerGetReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    public function __construct(
-        private ClassConstFetchReturnTypeResolver $classConstFetchReturnTypeResolver
-    ) {
-    }
-
     public function getClass(): string
     {
         return ContainerInterface::class;
@@ -39,6 +34,6 @@ final readonly class ContainerGetReturnTypeExtension implements DynamicMethodRet
         MethodCall $methodCall,
         Scope $scope
     ): ?Type {
-        return $this->classConstFetchReturnTypeResolver->resolve($methodReflection, $methodCall);
+        return ClassConstFetchReturnTypeResolver::resolve($methodReflection, $methodCall);
     }
 }

--- a/src/ReturnTypeExtension/Symfony/ContainerGetReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/Symfony/ContainerGetReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\ReturnTypeExtension;
+namespace Symplify\PHPStanRules\ReturnTypeExtension\Symfony;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;

--- a/src/ReturnTypeExtension/Symfony/SplFileInfoTolerantReturnTypeExtension.php
+++ b/src/ReturnTypeExtension/Symfony/SplFileInfoTolerantReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\ReturnTypeExtension;
+namespace Symplify\PHPStanRules\ReturnTypeExtension\Symfony;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;

--- a/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
+++ b/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\TypeResolver;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class ClassConstFetchReturnTypeResolver
+{
+    public function resolve(MethodReflection $methodReflection, MethodCall $methodCall): ?Type
+    {
+        if (! isset($methodCall->args[0])) {
+            return null;
+        }
+
+        $firstArgOrVariadciPlaceholder = $methodCall->args[0];
+        if (! $firstArgOrVariadciPlaceholder instanceof Arg) {
+            return new MixedType();
+        }
+
+        $firstValue = $firstArgOrVariadciPlaceholder->value;
+        if (! $firstValue instanceof ClassConstFetch) {
+            return new MixedType();
+        }
+
+        $className = null;
+        if ($firstValue->class instanceof Name && ($firstValue->name instanceof Identifier && $firstValue->name->toString() === 'class')) {
+            $className = $firstValue->class->toString();
+        }
+
+        if ($className !== null) {
+            return new ObjectType($className);
+        }
+
+        return null;
+    }
+}

--- a/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
+++ b/src/TypeResolver/ClassConstFetchReturnTypeResolver.php
@@ -16,7 +16,7 @@ use PHPStan\Type\Type;
 
 final class ClassConstFetchReturnTypeResolver
 {
-    public function resolve(MethodReflection $methodReflection, MethodCall $methodCall): ?Type
+    public static function resolve(MethodReflection $methodReflection, MethodCall $methodCall): ?Type
     {
         if (! isset($methodCall->args[0])) {
             return null;

--- a/tests/ErrorFormatter/Fixture/expected_single_message_many_files_report.txt
+++ b/tests/ErrorFormatter/Fixture/expected_single_message_many_files_report.txt
@@ -1,0 +1,10 @@
+ ---------------------------%s
+  /data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4
+ ---------------------------%s
+  - '#Foo#'
+ ---------------------------%s
+
+
+ [ERROR] Found 2 errors
+
+ [WARNING] first generic error

--- a/tests/ErrorFormatter/SymplifyErrorFormatterTest.php
+++ b/tests/ErrorFormatter/SymplifyErrorFormatterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ErrorFormatter;
+
+use Iterator;
+use Override;
+use PHPStan\Testing\ErrorFormatterTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\PHPStanRules\ErrorFormatter\SymplifyErrorFormatter;
+
+/**
+ * @see \Symplify\PHPStanRules\ErrorFormatter\SymplifyErrorFormatter
+ */
+final class SymplifyErrorFormatterTest extends ErrorFormatterTestCase
+{
+    #[DataProvider('provideData')]
+    public function testFormatErrors(
+        string $message,
+        int $expectedExitCode,
+        int $numFileErrors,
+        int $numGenericErrors,
+        string $expectedOutputFile,
+    ): void {
+        $symplifyErrorFormatter = self::getContainer()->getByType(SymplifyErrorFormatter::class);
+
+        $analysisResult = $this->getAnalysisResult($numFileErrors, $numGenericErrors);
+        $resultCode = $symplifyErrorFormatter->formatErrors($analysisResult, $this->getOutput());
+
+        $this->assertSame($expectedExitCode, $resultCode);
+
+        $this->assertStringMatchesFormatFile($expectedOutputFile, $this->getOutputContent());
+    }
+
+    /**
+     * @return Iterator<mixed>
+     */
+    public static function provideData(): Iterator
+    {
+        yield ['Some message', 1, 1, 1, __DIR__ . '/Fixture/expected_single_message_many_files_report.txt'];
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../config/phpstan-extensions.neon'];
+    }
+}

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/ContainerGetReturnTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/ContainerGetReturnTypeExtensionTest.php
@@ -10,7 +10,7 @@ use PHPStan\Testing\TypeInferenceTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @see \Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
  */
 final class ContainerGetReturnTypeExtensionTest extends TypeInferenceTestCase
 {

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/ContainerGetReturnTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/ContainerGetReturnTypeExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\ContainerGetReturnTypeExtension;
+
+use Iterator;
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+ */
+final class ContainerGetReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    #[DataProvider('dataAsserts')]
+    public function testAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return Iterator<array<string, mixed>>
+     */
+    public static function dataAsserts(): Iterator
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/container_get.php.inc');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/type_extension.neon'];
+    }
+}

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/Source/ExternalService.php
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/Source/ExternalService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\ContainerGetReturnTypeExtension\Source;
+
+final class ExternalService
+{
+}

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
@@ -1,0 +1,7 @@
+services:
+    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
+
+    # $container->get($1) => $1 type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
@@ -1,6 +1,4 @@
 services:
-    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
-
     # $container->get($1) => $1 type
     -
         class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/config/type_extension.neon
@@ -3,5 +3,5 @@ services:
 
     # $container->get($1) => $1 type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\ContainerGetReturnTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\ContainerGetReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/data/container_get.php.inc
+++ b/tests/ReturnTypeExtension/ContainerGetReturnTypeExtension/data/container_get.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symplify\PHPStanRules\Tests\ReturnTypeExtension\ContainerGetReturnTypeExtension\Source\ExternalService;
+use function PHPStan\Testing\assertType;
+
+final class SomeClass
+{
+    public function run(ContainerInterface $container): void
+    {
+        $service = $container->get(ExternalService::class);
+        assertType(ExternalService::class, $service);
+    }
+}

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/LaravelContainerMakeTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/LaravelContainerMakeTypeExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\LaravelContainerMakeTypeExtension;
+
+use Iterator;
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+ */
+final class LaravelContainerMakeTypeExtensionTest extends TypeInferenceTestCase
+{
+    #[DataProvider('dataAsserts')]
+    public function testAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return Iterator<array<string, mixed>>
+     */
+    public static function dataAsserts(): Iterator
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/container_make.php.inc');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/type_extension.neon'];
+    }
+}

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/LaravelContainerMakeTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/LaravelContainerMakeTypeExtensionTest.php
@@ -10,7 +10,7 @@ use PHPStan\Testing\TypeInferenceTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @see \Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
  */
 final class LaravelContainerMakeTypeExtensionTest extends TypeInferenceTestCase
 {

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/Source/ExternalService.php
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/Source/ExternalService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\LaravelContainerMakeTypeExtension\Source;
+
+final class ExternalService
+{
+}

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
@@ -3,5 +3,5 @@ services:
 
     # $container->make($1) => $1 type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
@@ -1,0 +1,7 @@
+services:
+    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
+
+    # $container->make($1) => $1 type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\LaravelContainerMakeTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/config/type_extension.neon
@@ -1,6 +1,4 @@
 services:
-    - Symplify\PHPStanRules\TypeResolver\ClassConstFetchReturnTypeResolver
-
     # $container->make($1) => $1 type
     -
         class: Symplify\PHPStanRules\ReturnTypeExtension\Laravel\LaravelContainerMakeTypeExtension

--- a/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/data/container_make.php.inc
+++ b/tests/ReturnTypeExtension/LaravelContainerMakeTypeExtension/data/container_make.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Container\Container;
+use Symplify\PHPStanRules\Tests\ReturnTypeExtension\LaravelContainerMakeTypeExtension\Source\ExternalService;
+use function PHPStan\Testing\assertType;
+
+final class SomeClass
+{
+    public function run(Container $container): void
+    {
+        $service = $container->make(ExternalService::class);
+        assertType(ExternalService::class, $service);
+
+        $service = $container->get(ExternalService::class);
+        assertType(ExternalService::class, $service);
+    }
+}

--- a/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/NativeFunctionReturnTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/NativeFunctionReturnTypeExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\NativeFunctionReturnTypeExtension;
+
+use Iterator;
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension
+ */
+final class NativeFunctionReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    #[DataProvider('dataAsserts')]
+    public function testAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return Iterator<array<string, mixed>>
+     */
+    public static function dataAsserts(): Iterator
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/native_function.php.inc');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/type_extension.neon'];
+    }
+}

--- a/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/config/type_extension.neon
@@ -1,0 +1,5 @@
+services:
+    # getcwd()/dirname()/realpath() => always "string"
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\NativeFunctionReturnTypeExtension
+        tags: [phpstan.broker.dynamicFunctionReturnTypeExtension]

--- a/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/data/native_function.php.inc
+++ b/tests/ReturnTypeExtension/NativeFunctionReturnTypeExtension/data/native_function.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+$currentWorkingDirectory = getcwd();
+assertType('string', $currentWorkingDirectory);

--- a/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/SplFileInfoTolerantReturnTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/SplFileInfoTolerantReturnTypeExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension;
+
+use Iterator;
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+ */
+final class SplFileInfoTolerantReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    #[DataProvider('dataAsserts')]
+    public function testAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return Iterator<array<string, mixed>>
+     */
+    public static function dataAsserts(): Iterator
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/spl_file_info_real_path.php.inc');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/type_extension.neon'];
+    }
+}

--- a/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/SplFileInfoTolerantReturnTypeExtensionTest.php
+++ b/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/SplFileInfoTolerantReturnTypeExtensionTest.php
@@ -10,7 +10,7 @@ use PHPStan\Testing\TypeInferenceTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @see \Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+ * @see \Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
  */
 final class SplFileInfoTolerantReturnTypeExtensionTest extends TypeInferenceTestCase
 {

--- a/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/config/type_extension.neon
@@ -1,0 +1,5 @@
+services:
+    # $splFileInfo->getRealPath() => string type
+    -
+        class: Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/config/type_extension.neon
+++ b/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/config/type_extension.neon
@@ -1,5 +1,5 @@
 services:
     # $splFileInfo->getRealPath() => string type
     -
-        class: Symplify\PHPStanRules\ReturnTypeExtension\SplFileInfoTolerantReturnTypeExtension
+        class: Symplify\PHPStanRules\ReturnTypeExtension\Symfony\SplFileInfoTolerantReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/data/spl_file_info_real_path.php.inc
+++ b/tests/ReturnTypeExtension/SplFileInfoTolerantReturnTypeExtension/data/spl_file_info_real_path.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\SplFileInfo;
+use function PHPStan\Testing\assertType;
+
+final class SomeClass
+{
+    public function run(SplFileInfo $splFileInfo): void
+    {
+        $realPath = $splFileInfo->getRealPath();
+        assertType('string', $realPath);
+    }
+}


### PR DESCRIPTION
Merges `symplify/phpstan-extensions` into this package (only a few classes), adding return type extensions and a Symplify error formatter.

All return type extensions are **disabled by default** and opt-in via parameters in your `phpstan.neon`:

```yaml
parameters:
    symfonyReturnType: true   # Container::get($id) => $id type; Finder SplFileInfo::getRealPath() => string
    laravelReturnType: true   # Container::make($class) => $class type
    pathStrings: true         # getcwd()/dirname()/realpath() => always "string"
```

| Parameter | Enables |
| --- | --- |
| `symfonyReturnType` | `ContainerGetReturnTypeExtension`, `SplFileInfoTolerantReturnTypeExtension` |
| `laravelReturnType` | `LaravelContainerMakeTypeExtension` |
| `pathStrings` | `NativeFunctionReturnTypeExtension` |

The `errorFormat: symplify` formatter is registered unconditionally.
