### PR TITLE
Remove invalid character from phpunit-rules.neon

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -13,6 +13,9 @@ jobs:
             matrix:
                 actions:
                     -
+                        name: 'Lint Neon'
+                        run: vendor/bin/neon-lint config/
+                    -
                         name: 'PHPStan'
                         run: composer phpstan --ansi
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "tomasvotruba/unused-public": "^2.2",
         "tomasvotruba/type-coverage": "^2.2",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "rector/jack": "^1.0"
+        "rector/jack": "^1.0",
+        "nette/neon": "^3.4"
     },
     "autoload": {
         "psr-4": {
@@ -53,6 +54,7 @@
     "scripts": {
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
+        "lint-neon": "vendor/bin/neon-lint config/",
         "phpstan": "vendor/bin/phpstan analyse --ansi",
         "rector": "vendor/bin/rector process --dry-run --ansi"
     },

--- a/config/phpunit-rules.neon
+++ b/config/phpunit-rules.neon
@@ -1,4 +1,3 @@
 rules:
     - Symplify\PHPStanRules\Rules\PHPUnit\PublicStaticDataProviderRule
     - Symplify\PHPStanRules\Rules\PHPUnit\NoAssertFuncCallInTestsRule
-ě


### PR DESCRIPTION
```shell
╰─ c phpstan:analyse                                                                                                                                                              ─╯
Note: Using configuration file /.../laravel-skeleton/phpstan.neon.dist.

In NeonCachedFileReader.php line 45:
                                                                                                                                                                             
  [_PHPStan_2874a496b\Nette\Neon\Exception]                                                                                                                                  
  Error while loading /.../laravel-skeleton/vendor/symplify/phpstan-rules/config/phpunit-rules.neon: Unexpected '<new line>' on line 4, column 3.  
                                                                                                                                                                             

```