### PR TITLE
[Rector] Skip deprecated rules in set + check bare int refactor() return

### DIFF
--- a/src/Doctrine/DoctrineEntityDocumentAnalyser.php
+++ b/src/Doctrine/DoctrineEntityDocumentAnalyser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Doctrine;
 
+use PHPStan\BetterReflection\Reflection\Adapter\FakeReflectionAttribute;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\Reflection\ClassReflection;
 
@@ -43,7 +45,7 @@ final readonly class DoctrineEntityDocumentAnalyser
 
         return array_any(
             $attributeReflections,
-            static fn ($reflectionAttribute): bool => in_array(
+            static fn (ReflectionAttribute|FakeReflectionAttribute $reflectionAttribute): bool => in_array(
                 $reflectionAttribute->getName(),
                 self::ENTITY_ATTRIBUTES,
                 true

--- a/src/Enum/ClassName.php
+++ b/src/Enum/ClassName.php
@@ -14,6 +14,8 @@ final class ClassName
 
     public const string CONFIGURABLE_RECTOR = 'Rector\Contract\Rector\ConfigurableRectorInterface';
 
+    public const string DEPRECATED_RECTOR = 'Rector\Configuration\Deprecation\Contract\DeprecatedInterface';
+
     public const string RECTOR_ATTRIBUTE_KEY = 'Rector\NodeTypeResolver\Node\AttributeKey';
 
     public const string MOCK_OBJECT_CLASS = 'PHPUnit\Framework\MockObject\MockObject';

--- a/src/NodeAnalyzer/AttributeFinder.php
+++ b/src/NodeAnalyzer/AttributeFinder.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Stmt\Property;
 
 final class AttributeFinder
 {
-    public function hasAttribute(ClassLike | ClassMethod | Property | Param $node, string $desiredAttributeClass): bool
+    public function hasAttribute(ClassLike|ClassMethod|Property|Param $node, string $desiredAttributeClass): bool
     {
         return (bool) $this->findAttribute($node, $desiredAttributeClass);
     }
@@ -21,7 +21,7 @@ final class AttributeFinder
     /**
      * @return Attribute[]
      */
-    private function findAttributes(ClassMethod | Property | ClassLike | Param $node): array
+    private function findAttributes(ClassMethod|Property|ClassLike|Param $node): array
     {
         $attributes = [];
 
@@ -33,7 +33,7 @@ final class AttributeFinder
     }
 
     private function findAttribute(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         string $desiredAttributeClass
     ): ?Attribute {
         $attributes = $this->findAttributes($node);

--- a/src/NodeAnalyzer/EnumAnalyzer.php
+++ b/src/NodeAnalyzer/EnumAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\NodeAnalyzer;
 
-use MyCLabs\Enum\Enum;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\Scope;

--- a/src/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/src/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -17,7 +17,7 @@ final class SimpleCallableNodeTraverser
      * @param callable(Node $node): (int|Node|null) $callable
      * @param Node|Node[]|null $nodes
      */
-    public function traverseNodesWithCallable(Node | array | null $nodes, callable $callable): void
+    public function traverseNodesWithCallable(Node|array|null $nodes, callable $callable): void
     {
         if ($nodes === null) {
             return;

--- a/src/Rules/ClassNameRespectsParentSuffixRule.php
+++ b/src/Rules/ClassNameRespectsParentSuffixRule.php
@@ -23,7 +23,7 @@ use Symplify\PHPStanRules\Naming\ClassToSuffixResolver;
  * @implements Rule<InClassNode>
  * @see \Symplify\PHPStanRules\Tests\Rules\ClassNameRespectsParentSuffixRule\ClassNameRespectsParentSuffixRuleTest
  */
-final class ClassNameRespectsParentSuffixRule implements Rule
+final readonly class ClassNameRespectsParentSuffixRule implements Rule
 {
     public const string ERROR_MESSAGE = 'Class should have suffix "%s" to respect parent type';
 
@@ -45,13 +45,13 @@ final class ClassNameRespectsParentSuffixRule implements Rule
     /**
      * @var string[]
      */
-    private array $parentClasses = [];
+    private array $parentClasses;
 
     /**
      * @param class-string[] $parentClasses
      */
     public function __construct(
-        private readonly ClassToSuffixResolver $classToSuffixResolver,
+        private ClassToSuffixResolver $classToSuffixResolver,
         array $parentClasses = [],
     ) {
         $this->parentClasses = array_merge($parentClasses, self::DEFAULT_PARENT_CLASSES);

--- a/src/Rules/Complexity/NoJustPropertyAssignRule.php
+++ b/src/Rules/Complexity/NoJustPropertyAssignRule.php
@@ -124,7 +124,8 @@ final readonly class NoJustPropertyAssignRule implements Rule
         }
 
         $exprType = $scope->getType($assign->expr);
-        return $exprType->isObject()->yes();
+        return $exprType->isObject()
+            ->yes();
     }
 
     private function shouldSkipCurrentClass(Scope $scope): bool

--- a/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
+++ b/src/Rules/Doctrine/NoGetRepositoryOnServiceRepositoryEntityRule.php
@@ -110,7 +110,8 @@ final readonly class NoGetRepositoryOnServiceRepositoryEntityRule implements Rul
             return null;
         }
 
-        $firstArgument = $methodCall->getArgs()[0]->value;
+        $firstArgument = $methodCall->getArgs()[0]
+            ->value;
 
         $entityClassType = $scope->getType($firstArgument);
         if (! $entityClassType instanceof ConstantStringType) {

--- a/src/Rules/ForbiddenNodeRule.php
+++ b/src/Rules/ForbiddenNodeRule.php
@@ -18,16 +18,16 @@ use Webmozart\Assert\Assert;
  * @see \Symplify\PHPStanRules\Tests\Rules\ForbiddenNodeRule\ForbiddenNodeRuleTest
  * @implements Rule<Node>
  */
-final class ForbiddenNodeRule implements Rule
+final readonly class ForbiddenNodeRule implements Rule
 {
     public const string ERROR_MESSAGE = '"%s" is forbidden to use';
 
     /**
      * @var array<class-string<Node>>
      */
-    private array $forbiddenNodes = [];
+    private array $forbiddenNodes;
 
-    private readonly Standard $standard;
+    private Standard $standard;
 
     /**
      * @param array<class-string<Node>> $forbiddenNodes

--- a/src/Rules/PreferredClassRule.php
+++ b/src/Rules/PreferredClassRule.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Param;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
 use PHPStan\Reflection\ClassReflection;

--- a/src/Rules/Rector/NoClassReflectionStaticReflectionRule.php
+++ b/src/Rules/Rector/NoClassReflectionStaticReflectionRule.php
@@ -45,7 +45,8 @@ final class NoClassReflectionStaticReflectionRule implements Rule
             return [];
         }
 
-        $argValue = $node->getArgs()[0]->value;
+        $argValue = $node->getArgs()[0]
+            ->value;
         $exprStaticType = $scope->getType($argValue);
 
         if (RectorAllowedAutoloadedTypeAnalyzer::isAllowedType($exprStaticType)) {

--- a/src/Rules/Rector/NoInstanceOfStaticReflectionRule.php
+++ b/src/Rules/Rector/NoInstanceOfStaticReflectionRule.php
@@ -67,7 +67,8 @@ final class NoInstanceOfStaticReflectionRule implements Rule
             return null;
         }
 
-        $typeArgValue = $node->getArgs()[1]->value;
+        $typeArgValue = $node->getArgs()[1]
+            ->value;
         return $scope->getType($typeArgValue);
     }
 

--- a/src/Rules/Rector/NoIntegerRefactorReturnRule.php
+++ b/src/Rules/Rector/NoIntegerRefactorReturnRule.php
@@ -46,34 +46,41 @@ final class NoIntegerRefactorReturnRule implements Rule
             return [];
         }
 
-        if (! $node->returnType instanceof UnionType) {
+        if (! $this->hasIntReturnType($node->returnType)) {
             return [];
         }
 
-        foreach ($node->returnType->types as $type) {
-            if (! $type instanceof Identifier) {
-                continue;
-            }
+        $constantNames = $this->findUsedNodeVisitorConstantNames($node);
 
-            if ($type->name !== 'int') {
-                continue;
-            }
-
-            $constantNames = $this->findUsedNodeVisitorConstantNames($node);
-
-            $undesiredConstantNames = array_diff($constantNames, ['REMOVE_NODE']);
-            if ($constantNames !== [] && $undesiredConstantNames === []) {
-                return [];
-            }
-
-            $ruleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-                ->identifier(RectorRuleIdentifier::NO_INTEGER_REFACTOR_RETURN)
-                ->build();
-
-            return [$ruleError];
+        $undesiredConstantNames = array_diff($constantNames, ['REMOVE_NODE']);
+        if ($constantNames !== [] && $undesiredConstantNames === []) {
+            return [];
         }
 
-        return [];
+        $ruleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+            ->identifier(RectorRuleIdentifier::NO_INTEGER_REFACTOR_RETURN)
+            ->build();
+
+        return [$ruleError];
+    }
+
+    private function hasIntReturnType(?Node $returnType): bool
+    {
+        // bare "int" return type
+        if ($returnType instanceof Identifier) {
+            return $returnType->name === 'int';
+        }
+
+        // "int" as one of the union members
+        if ($returnType instanceof UnionType) {
+            foreach ($returnType->types as $type) {
+                if ($type instanceof Identifier && $type->name === 'int') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Rules/Rector/NoIntegerRefactorReturnRule.php
+++ b/src/Rules/Rector/NoIntegerRefactorReturnRule.php
@@ -57,23 +57,23 @@ final class NoIntegerRefactorReturnRule implements Rule
             return [];
         }
 
-        $ruleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+        $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
             ->identifier(RectorRuleIdentifier::NO_INTEGER_REFACTOR_RETURN)
             ->build();
 
-        return [$ruleError];
+        return [$identifierRuleError];
     }
 
-    private function hasIntReturnType(?Node $returnType): bool
+    private function hasIntReturnType(?Node $node): bool
     {
         // bare "int" return type
-        if ($returnType instanceof Identifier) {
-            return $returnType->name === 'int';
+        if ($node instanceof Identifier) {
+            return $node->name === 'int';
         }
 
         // "int" as one of the union members
-        if ($returnType instanceof UnionType) {
-            foreach ($returnType->types as $type) {
+        if ($node instanceof UnionType) {
+            foreach ($node->types as $type) {
                 if ($type instanceof Identifier && $type->name === 'int') {
                     return true;
                 }

--- a/src/Rules/Rector/NoLeadingBackslashInNameRule.php
+++ b/src/Rules/Rector/NoLeadingBackslashInNameRule.php
@@ -47,7 +47,8 @@ final class NoLeadingBackslashInNameRule implements Rule
             return [];
         }
 
-        $argValue = $node->getArgs()[0]->value;
+        $argValue = $node->getArgs()[0]
+            ->value;
         $argType = $scope->getType($argValue);
 
         if (! $argType instanceof ConstantStringType) {

--- a/src/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule.php
+++ b/src/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule.php
@@ -115,6 +115,11 @@ final class PhpUpgradeDowngradeRegisteredInSetRule implements Rule
             return null;
         }
 
+        // deprecated Rector rules are not registered in sets
+        if ($classReflection->is(ClassName::DEPRECATED_RECTOR)) {
+            return null;
+        }
+
         return $classReflection->getName();
     }
 }

--- a/src/Rules/Symfony/ConfigClosure/NoDuplicateArgAutowireByTypeRule.php
+++ b/src/Rules/Symfony/ConfigClosure/NoDuplicateArgAutowireByTypeRule.php
@@ -86,7 +86,8 @@ final readonly class NoDuplicateArgAutowireByTypeRule implements Rule
 
         // 1. compare referenced type and constructor type
         $classArgumentNamesToTypes = $this->classConstructorTypesResolver->resolveClassConstructorNamesToTypes($node);
-        $referenceExpr = $referenceFuncCall->getArgs()[0]->value;
+        $referenceExpr = $referenceFuncCall->getArgs()[0]
+            ->value;
 
         if (isset($classArgumentNamesToTypes[$currentArgumentName])) {
             $constructorType = $classArgumentNamesToTypes[$currentArgumentName];

--- a/src/Rules/Symfony/ConfigClosure/NoDuplicateArgsAutowireByTypeRule.php
+++ b/src/Rules/Symfony/ConfigClosure/NoDuplicateArgsAutowireByTypeRule.php
@@ -84,7 +84,8 @@ final readonly class NoDuplicateArgsAutowireByTypeRule implements Rule
             }
 
             $referenceFuncCall = $arrayItem->value;
-            $referenceExpr = $referenceFuncCall->getArgs()[0]->value;
+            $referenceExpr = $referenceFuncCall->getArgs()[0]
+                ->value;
 
             if (! $referenceExpr instanceof ClassConstFetch) {
                 continue;

--- a/src/Rules/Symfony/ConfigClosure/NoServiceSameNameSetClassRule.php
+++ b/src/Rules/Symfony/ConfigClosure/NoServiceSameNameSetClassRule.php
@@ -98,8 +98,10 @@ final readonly class NoServiceSameNameSetClassRule implements Rule
             return null;
         }
 
-        $serviceName = $methodCall->getArgs()[0]->value;
-        $serviceType = $methodCall->getArgs()[1]->value;
+        $serviceName = $methodCall->getArgs()[0]
+            ->value;
+        $serviceType = $methodCall->getArgs()[1]
+            ->value;
 
         if (! $serviceName instanceof ClassConstFetch) {
             return null;

--- a/src/Rules/Symfony/ConfigClosure/ServicesExcludedDirectoryMustExistRule.php
+++ b/src/Rules/Symfony/ConfigClosure/ServicesExcludedDirectoryMustExistRule.php
@@ -53,7 +53,8 @@ final class ServicesExcludedDirectoryMustExistRule implements Rule
 
         foreach ($excludeMethodCalls as $excludeMethodCall) {
             // check all array args
-            $firstArgValue = $excludeMethodCall->getArgs()[0]->value;
+            $firstArgValue = $excludeMethodCall->getArgs()[0]
+                ->value;
             if (! $firstArgValue instanceof Array_) {
                 continue;
             }

--- a/src/Rules/Symfony/NoRoutingPrefixRule.php
+++ b/src/Rules/Symfony/NoRoutingPrefixRule.php
@@ -73,7 +73,8 @@ final class NoRoutingPrefixRule implements Rule
             return false;
         }
 
-        $importArgPath = $parentCaller->getArgs()[0]->value;
+        $importArgPath = $parentCaller->getArgs()[0]
+            ->value;
         if (! $importArgPath instanceof String_) {
             return false;
         }

--- a/src/Symfony/ConfigClosure/SymfonyClosureServicesExcludeResolver.php
+++ b/src/Symfony/ConfigClosure/SymfonyClosureServicesExcludeResolver.php
@@ -40,7 +40,8 @@ final class SymfonyClosureServicesExcludeResolver
                 return false;
             }
 
-            $excludedExpr = $node->getArgs()[0]->value;
+            $excludedExpr = $node->getArgs()[0]
+                ->value;
             if (! $excludedExpr instanceof Array_) {
                 return false;
             }

--- a/src/Symfony/ConfigClosure/SymfonyClosureServicesLoadResolver.php
+++ b/src/Symfony/ConfigClosure/SymfonyClosureServicesLoadResolver.php
@@ -36,7 +36,8 @@ final class SymfonyClosureServicesLoadResolver
                 return false;
             }
 
-            $namespaceExpr = $node->getArgs()[0]->value;
+            $namespaceExpr = $node->getArgs()[0]
+                ->value;
             if (! $namespaceExpr instanceof String_) {
                 return false;
             }

--- a/src/Symfony/ConfigClosure/SymfonyClosureServicesSetClassesResolver.php
+++ b/src/Symfony/ConfigClosure/SymfonyClosureServicesSetClassesResolver.php
@@ -52,7 +52,8 @@ final class SymfonyClosureServicesSetClassesResolver
                 return false;
             }
 
-            $setServiceExpr = $methodCall->getArgs()[0]->value;
+            $setServiceExpr = $methodCall->getArgs()[0]
+                ->value;
             if (! $setServiceExpr instanceof ClassConstFetch) {
                 return false;
             }

--- a/src/Symfony/NodeAnalyzer/SymfonyControllerAnalyzer.php
+++ b/src/Symfony/NodeAnalyzer/SymfonyControllerAnalyzer.php
@@ -36,7 +36,7 @@ final class SymfonyControllerAnalyzer
         return self::hasRouteAnnotationOrAttribute($classMethod);
     }
 
-    public static function hasRouteAnnotationOrAttribute(ClassLike | ClassMethod $node): bool
+    public static function hasRouteAnnotationOrAttribute(ClassLike|ClassMethod $node): bool
     {
         if ($node instanceof ClassMethod && ! $node->isPublic()) {
             return false;

--- a/src/Symfony/NodeFinder/RepeatedServiceAdderCallNameFinder.php
+++ b/src/Symfony/NodeFinder/RepeatedServiceAdderCallNameFinder.php
@@ -25,11 +25,13 @@ final class RepeatedServiceAdderCallNameFinder
 
         foreach ($callMethodCalls as $callMethodCall) {
             /** @var String_ $calledMethodNameExpr */
-            $calledMethodNameExpr = $callMethodCall->getArgs()[0]->value;
+            $calledMethodNameExpr = $callMethodCall->getArgs()[0]
+                ->value;
             $callMethodName = $calledMethodNameExpr->value;
 
             // is passing a service references?
-            $passedExpr = $callMethodCall->getArgs()[1]->value;
+            $passedExpr = $callMethodCall->getArgs()[1]
+                ->value;
             if (! $passedExpr instanceof Array_) {
                 continue;
             }
@@ -79,7 +81,8 @@ final class RepeatedServiceAdderCallNameFinder
                 return false;
             }
 
-            $callNameExpr = $node->getArgs()[0]->value;
+            $callNameExpr = $node->getArgs()[0]
+                ->value;
             return $callNameExpr instanceof String_;
         });
 

--- a/src/Symfony/Reflection/ClassConstructorTypesResolver.php
+++ b/src/Symfony/Reflection/ClassConstructorTypesResolver.php
@@ -62,7 +62,8 @@ final readonly class ClassConstructorTypesResolver
                 continue;
             }
 
-            $serviceClassOrName = $currentMethodCall->getArgs()[0]->value;
+            $serviceClassOrName = $currentMethodCall->getArgs()[0]
+                ->value;
             if ($serviceClassOrName instanceof ClassConstFetch) {
                 return NamingHelper::getName($serviceClassOrName->class);
             }

--- a/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/AllowBareIntRemoveNode.php
+++ b/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/AllowBareIntRemoveNode.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\NoIntegerRefactorReturnRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeVisitor;
+use Rector\Rector\AbstractRector;
+
+final class AllowBareIntRemoveNode extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): int
+    {
+        return NodeVisitor::REMOVE_NODE;
+    }
+}

--- a/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/BareIntReturn.php
+++ b/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/BareIntReturn.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\NoIntegerRefactorReturnRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeVisitor;
+use Rector\Rector\AbstractRector;
+
+final class BareIntReturn extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): int
+    {
+        return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+    }
+}

--- a/tests/Rules/Rector/NoIntegerRefactorReturnRule/NoIntegerRefactorReturnRuleTest.php
+++ b/tests/Rules/Rector/NoIntegerRefactorReturnRule/NoIntegerRefactorReturnRuleTest.php
@@ -32,8 +32,11 @@ final class NoIntegerRefactorReturnRuleTest extends RuleTestCase
         $errorMessage = NoIntegerRefactorReturnRule::ERROR_MESSAGE;
         yield [__DIR__ . '/Fixture/NestedReturnInt.php', [[$errorMessage, 20]]];
 
+        yield [__DIR__ . '/Fixture/BareIntReturn.php', [[$errorMessage, 19]]];
+
         yield [__DIR__ . '/Fixture/SkipBareNodeReturn.php', []];
         yield [__DIR__ . '/Fixture/AllowRemoveNode.php', []];
+        yield [__DIR__ . '/Fixture/AllowBareIntRemoveNode.php', []];
         yield [__DIR__ . '/Fixture/AllowNestedClosure.php', []];
     }
 

--- a/tests/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule/Fixture/Php80/SkipDeprecatedRector.php
+++ b/tests/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule/Fixture/Php80/SkipDeprecatedRector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\PhpUpgradeDowngradeRegisteredInSetRule\Fixture\Php80;
+
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+use Rector\Contract\Rector\RectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class SkipDeprecatedRector implements RectorInterface, DeprecatedInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+}

--- a/tests/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule/PhpUpgradeDowngradeRegisteredInSetRuleTest.php
+++ b/tests/Rules/Rector/PhpUpgradeDowngradeRegisteredInSetRule/PhpUpgradeDowngradeRegisteredInSetRuleTest.php
@@ -30,6 +30,7 @@ final class PhpUpgradeDowngradeRegisteredInSetRuleTest extends RuleTestCase
     {
         yield [__DIR__ . '/Fixture/SkipSomePhpFeatureRector.php', []];
         yield [__DIR__ . '/Fixture/Php80/SkipConfigurableRector.php', []];
+        yield [__DIR__ . '/Fixture/Php80/SkipDeprecatedRector.php', []];
 
         $errorMessage = sprintf(
             PhpUpgradeDowngradeRegisteredInSetRule::ERROR_MESSAGE,


### PR DESCRIPTION
Two `src/Rules/Rector/` improvements.

## 1. `PhpUpgradeDowngradeRegisteredInSetRule` — skip deprecated rules

The rule demands every `Php*`/`DowngradePhp*` Rector rule be registered in its matching config set:

```
Register "Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector" service to "php73.php" config set
```

Deprecated rules (marker `Rector\Configuration\Deprecation\Contract\DeprecatedInterface`) are on their way out and are **not** registered in sets, so they are now skipped — same treatment as `ConfigurableRectorInterface`.

```php
use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
use Rector\Contract\Rector\RectorInterface;

// before: "Register ... to php80.php config set"   after: skipped
final class SomeDeprecatedPhp80Rector implements RectorInterface, DeprecatedInterface
{
}
```

## 2. `NoIntegerRefactorReturnRule` — also check bare `int` return type

Previously only a `UnionType` return type (e.g. `Node|int`) was inspected; a bare `int` return type slipped through unchecked. Now bare `int` is checked too, while `REMOVE_NODE` stays allowed.

```php
// now reported — was silently skipped before
public function refactor(Node $node): int
{
    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
}

// allowed
public function refactor(Node $node): int
{
    return NodeVisitor::REMOVE_NODE;
}
```