### PR TITLE
[NoMissnamedDocTagRule] Skip @return/@param inside constant prose docblock

### DIFF
--- a/src/Rules/NoMissnamedDocTagRule.php
+++ b/src/Rules/NoMissnamedDocTagRule.php
@@ -87,7 +87,7 @@ final class NoMissnamedDocTagRule implements Rule
                 continue;
             }
 
-            $matches = Strings::match($classConst->getDocComment()->getText(), '#(@param|@return)\b#mi');
+            $matches = Strings::match($classConst->getDocComment()->getText(), '#\*\s(@param|@return)\b#mi');
             if ($matches === null) {
                 continue;
             }

--- a/tests/Rules/NoMissnamedDocTagRule/Fixture/SkipConstantPartOfComment.php
+++ b/tests/Rules/NoMissnamedDocTagRule/Fixture/SkipConstantPartOfComment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoMissnamedDocTagRule\Fixture;
+
+final class SkipConstantPartOfComment
+{
+    /**
+     * Using 10-level array @return docblocks makes code very hard to read,
+     * lets limit it to reasonable level
+     */
+    private const int MAX_NESTING = 3;
+}

--- a/tests/Rules/NoMissnamedDocTagRule/NoMissnamedDocTagRuleTest.php
+++ b/tests/Rules/NoMissnamedDocTagRule/NoMissnamedDocTagRuleTest.php
@@ -41,6 +41,7 @@ final class NoMissnamedDocTagRuleTest extends RuleTestCase
 
         yield [__DIR__ . '/Fixture/SkipValidPropertyTag.php', []];
         yield [__DIR__ . '/Fixture/SkipPartOfComment.php', []];
+        yield [__DIR__ . '/Fixture/SkipConstantPartOfComment.php', []];
     }
 
     /**


### PR DESCRIPTION
`NoMissnamedDocTagRule` flagged constants whose docblock merely *mentions* `@return`/`@param` inside prose — not as a real tag. Method/property checks already require the tag to sit at the start of a docblock line (`* @tag`); the constant check did not. Aligned the constant regex to the same `#\*\s(@param|@return)\b#` shape.

### Before — false positive

```php
/**
 * Using 10-level array @return docblocks makes code very hard to read,
 * lets limit it to reasonable level
 */
private const int MAX_NESTING = 3;
// ❌ Constant doc comment tag must be @var, "@return" given
```

### After — skipped

Same code, no error. A real misnamed tag is still reported:

```php
/**
 * @return string
 */
private const NAME = 'value';
// ❌ Constant doc comment tag must be @var, "@return" given
```