### PR TITLE
[Rector] Skip refactor() delegating REMOVE_NODE to helper methods

### DIFF
--- a/src/Rules/Rector/NoIntegerRefactorReturnRule.php
+++ b/src/Rules/Rector/NoIntegerRefactorReturnRule.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType;
 use PhpParser\NodeTraverser;
@@ -22,7 +23,7 @@ use Symplify\PHPStanRules\NodeTraverser\SimpleCallableNodeTraverser;
 /**
  * @see \Symplify\PHPStanRules\Tests\Rules\Rector\NoIntegerRefactorReturnRule\NoIntegerRefactorReturnRuleTest
  *
- * @implements Rule<ClassMethod>
+ * @implements Rule<Class_>
  */
 final class NoIntegerRefactorReturnRule implements Rule
 {
@@ -30,35 +31,38 @@ final class NoIntegerRefactorReturnRule implements Rule
 
     public function getNodeType(): string
     {
-        return ClassMethod::class;
+        return Class_::class;
     }
 
     /**
-     * @param ClassMethod $node
+     * @param Class_ $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! $node->isPublic()) {
+        $refactorClassMethod = $node->getMethod('refactor');
+        if (! $refactorClassMethod instanceof ClassMethod) {
             return [];
         }
 
-        if ($node->name->toString() !== 'refactor') {
+        if (! $refactorClassMethod->isPublic()) {
             return [];
         }
 
-        if (! $this->hasIntReturnType($node->returnType)) {
+        if (! $this->hasIntReturnType($refactorClassMethod->returnType)) {
             return [];
         }
 
+        // scan the whole class, as refactor() often delegates the int return to private helper methods
         $constantNames = $this->findUsedNodeVisitorConstantNames($node);
 
         $undesiredConstantNames = array_diff($constantNames, ['REMOVE_NODE']);
-        if ($constantNames !== [] && $undesiredConstantNames === []) {
+        if ($undesiredConstantNames === []) {
             return [];
         }
 
         $identifierRuleError = RuleErrorBuilder::message(self::ERROR_MESSAGE)
             ->identifier(RectorRuleIdentifier::NO_INTEGER_REFACTOR_RETURN)
+            ->line($refactorClassMethod->getStartLine())
             ->build();
 
         return [$identifierRuleError];
@@ -86,12 +90,12 @@ final class NoIntegerRefactorReturnRule implements Rule
     /**
      * @return string[]
      */
-    private function findUsedNodeVisitorConstantNames(ClassMethod $classMethod): array
+    private function findUsedNodeVisitorConstantNames(Class_ $class): array
     {
         $constantNames = [];
 
         $simpleCallableNodeTraverser = new SimpleCallableNodeTraverser();
-        $simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod, function (Node $subNode) use (&$constantNames): int|null {
+        $simpleCallableNodeTraverser->traverseNodesWithCallable($class, function (Node $subNode) use (&$constantNames): int|null {
             // skip closure nodes as they have their own scope
             if ($subNode instanceof Closure) {
                 return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;

--- a/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/SkipDelegatedRemoveNode.php
+++ b/tests/Rules/Rector/NoIntegerRefactorReturnRule/Fixture/SkipDelegatedRemoveNode.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\NoIntegerRefactorReturnRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeVisitor;
+use Rector\Rector\AbstractRector;
+
+final class SkipDelegatedRemoveNode extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): null|int
+    {
+        return $this->refactorClass($node);
+    }
+
+    private function refactorClass(Node $node): null|int
+    {
+        if ($node instanceof Class_) {
+            return NodeVisitor::REMOVE_NODE;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Rector/NoIntegerRefactorReturnRule/NoIntegerRefactorReturnRuleTest.php
+++ b/tests/Rules/Rector/NoIntegerRefactorReturnRule/NoIntegerRefactorReturnRuleTest.php
@@ -38,6 +38,7 @@ final class NoIntegerRefactorReturnRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/AllowRemoveNode.php', []];
         yield [__DIR__ . '/Fixture/AllowBareIntRemoveNode.php', []];
         yield [__DIR__ . '/Fixture/AllowNestedClosure.php', []];
+        yield [__DIR__ . '/Fixture/SkipDelegatedRemoveNode.php', []];
     }
 
     protected function getRule(): Rule


### PR DESCRIPTION
`NoIntegerRefactorReturnRule` only scanned the `refactor()` body for `NodeVisitor`/`NodeTraverser` constants. When `refactor()` delegates the int return to private helper methods, its own body contains **zero** constants — the old `$constantNames === []` branch then fell through and reported an error, even when every helper returned the allowed `REMOVE_NODE`.

Real-world false positive: Rector's own `RemovePhpVersionIdCheckRector`, whose `refactor()` delegates entirely to `refactorConstFetch()` / `refactorSmaller()` / etc., all returning `NodeVisitor::REMOVE_NODE`.

## Fix

Scan the **whole class** for used traverser constants (refactor helpers included), and only report when an **undesired** constant (anything other than `REMOVE_NODE`) is actually present.

## Before / after

```php
// bad — helper uses DONT_TRAVERSE_CHILDREN, still flagged
public function refactor(Node $node): null|int
{
    return $this->doRefactor($node);
}
private function doRefactor(Node $node): null|int
{
    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
}
```

```php
// good — helper only returns REMOVE_NODE, now correctly skipped
public function refactor(Node $node): null|int
{
    return $this->doRefactor($node);
}
private function doRefactor(Node $node): null|int
{
    return NodeVisitor::REMOVE_NODE;
}
```