### PR TITLE
Skip RectorCheaperGuardsFirstRule when anchor is not hoist-safe

### DIFF
--- a/src/Rules/Rector/RectorCheaperGuardsFirstRule.php
+++ b/src/Rules/Rector/RectorCheaperGuardsFirstRule.php
@@ -98,6 +98,12 @@ final class RectorCheaperGuardsFirstRule implements Rule
             return [];
         }
 
+        // only hoist past an anchor that just captures the expensive value or bails on it;
+        // an anchor with its own side effects (attribute writes, by-ref closure mutations) is unsafe to skip
+        if (! $this->isHoistSafeAnchor($stmts[$anchorIndex])) {
+            return [];
+        }
+
         $assignedVariableNames = $this->resolveAssignedVariableNames($stmts[$anchorIndex]);
         $counter = count($stmts);
 
@@ -131,6 +137,25 @@ final class RectorCheaperGuardsFirstRule implements Rule
         }
 
         return [];
+    }
+
+    /**
+     * The anchor is safe to hoist a guard above only when it merely produces the expensive value:
+     * either `$type = $this->getType(...)` (assignment) or `if ($this->isObjectType(...)) { return; }`
+     * (pure bail guard). Anything else - a block that writes attributes, a bare call statement that
+     * mutates state - would lose its side effect for the nodes the hoisted guard bails out on.
+     */
+    private function isHoistSafeAnchor(Stmt $stmt): bool
+    {
+        if ($stmt instanceof Expression) {
+            return $stmt->expr instanceof Assign;
+        }
+
+        if ($stmt instanceof If_) {
+            return $this->isPureBailGuard($stmt) && $this->containsCall($stmt->cond, self::EXPENSIVE_CALLS);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Rules/Rector/RectorCheaperGuardsFirstRule/Fixture/SkipByRefClosureAnchor.php
+++ b/tests/Rules/Rector/RectorCheaperGuardsFirstRule/Fixture/SkipByRefClosureAnchor.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\RectorCheaperGuardsFirstRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+
+final class SkipByRefClosureAnchor extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        $hasChanged = false;
+
+        // the expensive call runs inside a closure that mutates $hasChanged by-reference;
+        // the anchor is a bare call statement, not a captured value, so hoisting is unsafe
+        $this->traverseNodesWithCallable($node, function (Node $subNode) use (&$hasChanged) {
+            if ($subNode->getType()->isString()->yes()) {
+                $hasChanged = true;
+            }
+
+            return null;
+        });
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/tests/Rules/Rector/RectorCheaperGuardsFirstRule/Fixture/SkipSideEffectAnchor.php
+++ b/tests/Rules/Rector/RectorCheaperGuardsFirstRule/Fixture/SkipSideEffectAnchor.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Rector\RectorCheaperGuardsFirstRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+
+final class SkipSideEffectAnchor extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        // the anchor block writes attributes for non-substr nodes; the guard cannot hoist above it
+        if ($node instanceof CallLike) {
+            foreach ($node->getArgs() as $arg) {
+                if ($arg->value->getType()->isString()->yes()) {
+                    $arg->setAttribute('marked', true);
+                }
+            }
+        }
+
+        if (! $this->isName($node, 'substr')) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/tests/Rules/Rector/RectorCheaperGuardsFirstRule/RectorCheaperGuardsFirstRuleTest.php
+++ b/tests/Rules/Rector/RectorCheaperGuardsFirstRule/RectorCheaperGuardsFirstRuleTest.php
@@ -30,6 +30,10 @@ final class RectorCheaperGuardsFirstRuleTest extends RuleTestCase
 
         yield [__DIR__ . '/Fixture/SkipDependentGuard.php', []];
 
+        yield [__DIR__ . '/Fixture/SkipSideEffectAnchor.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipByRefClosureAnchor.php', []];
+
         yield [__DIR__ . '/Fixture/ExpensiveBeforeCheapGuard.php', [
             [
                 sprintf(RectorCheaperGuardsFirstRule::ERROR_MESSAGE, 26, 20),


### PR DESCRIPTION
`RectorCheaperGuardsFirstRule` (added in 14.13.0) produced false positives on rules where the cheap guard **cannot** be hoisted above the expensive call:

- an anchor block that writes attributes for the very nodes the guard would bail out on (e.g. `DowngradeSubstrFalsyRector` marking `IS_FALSY_UNCASTABLE` on non-substr call args);
- a bare call statement whose closure mutates a variable **by reference**, which the guard then reads (e.g. `TypeWillReturnCallableArrowFunctionRector` with `$hasChanged`).

Fix: only flag when the anchor is genuinely hoist-safe - either an assignment that just captures the expensive value, or a pure bail guard whose condition holds the expensive call. Anything else is skipped.

Adds two skip fixtures reproducing both patterns; the true-positive fixture still reports. Verified against the real rector-downgrade-php and rector-phpunit files: both pass with no ignore needed.