### PR TITLE
Fix ReflectionParser picking the first class-like in a multi-class-like file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         ],
         "files": [
             "vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php",
-            "tests/Rules/Rector/PhpUpgradeImplementsMinPhpVersionInterfaceRule/Fixture/SomePhpFeatureRector.php"
+            "tests/Rules/Rector/PhpUpgradeImplementsMinPhpVersionInterfaceRule/Fixture/SomePhpFeatureRector.php",
+            "tests/Reflection/Fixture/TwoClassLikes.php"
         ]
     },
     "config": {

--- a/src/NodeFinder/TypeAwareNodeFinder.php
+++ b/src/NodeFinder/TypeAwareNodeFinder.php
@@ -30,4 +30,16 @@ final readonly class TypeAwareNodeFinder
     {
         return $this->nodeFinder->findFirstInstanceOf($nodes, $type);
     }
+
+    /**
+     * @template TNode as Node
+     *
+     * @param Node[]|Node $nodes
+     * @param class-string<TNode> $type
+     * @return TNode[]
+     */
+    public function findInstanceOf(array|Node $nodes, string $type): array
+    {
+        return $this->nodeFinder->findInstanceOf($nodes, $type);
+    }
 }

--- a/src/Reflection/ReflectionParser.php
+++ b/src/Reflection/ReflectionParser.php
@@ -23,7 +23,7 @@ final class ReflectionParser
     /**
      * @var array<string, ClassLike>
      */
-    private array $classesByFilename = [];
+    private array $classLikesByName = [];
 
     private readonly Parser $parser;
 
@@ -54,7 +54,7 @@ final class ReflectionParser
             return null;
         }
 
-        return $this->parseFilenameToClass($fileName);
+        return $this->parseFilenameToClass($fileName, $classReflection->getName());
     }
 
     private function parseNativeClassReflection(ReflectionClass|ClassReflection $reflectionClass): ?ClassLike
@@ -68,13 +68,13 @@ final class ReflectionParser
             return null;
         }
 
-        return $this->parseFilenameToClass($fileName);
+        return $this->parseFilenameToClass($fileName, $reflectionClass->getName());
     }
 
-    private function parseFilenameToClass(string $fileName): ClassLike|null
+    private function parseFilenameToClass(string $fileName, string $className): ClassLike|null
     {
-        if (isset($this->classesByFilename[$fileName])) {
-            return $this->classesByFilename[$fileName];
+        if (isset($this->classLikesByName[$className])) {
+            return $this->classLikesByName[$className];
         }
 
         try {
@@ -92,13 +92,16 @@ final class ReflectionParser
             return null;
         }
 
-        $classLike = $this->typeAwareNodeFinder->findFirstInstanceOf($stmts, ClassLike::class);
-        if (! $classLike instanceof ClassLike) {
-            return null;
+        foreach ($this->typeAwareNodeFinder->findInstanceOf($stmts, ClassLike::class) as $classLike) {
+            if ($classLike->namespacedName?->toString() !== $className) {
+                continue;
+            }
+
+            $this->classLikesByName[$className] = $classLike;
+
+            return $classLike;
         }
 
-        $this->classesByFilename[$fileName] = $classLike;
-
-        return $classLike;
+        return null;
     }
 }

--- a/tests/Reflection/Fixture/TwoClassLikes.php
+++ b/tests/Reflection/Fixture/TwoClassLikes.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Reflection\Fixture;
+
+final class FirstClassLike
+{
+    public function firstMethod(): void
+    {
+    }
+}
+
+final class SecondClassLike
+{
+    public function secondMethod(): void
+    {
+    }
+}

--- a/tests/Reflection/ReflectionParserTest.php
+++ b/tests/Reflection/ReflectionParserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Reflection;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symplify\PHPStanRules\NodeFinder\TypeAwareNodeFinder;
+use Symplify\PHPStanRules\Reflection\ReflectionParser;
+use Symplify\PHPStanRules\Tests\Reflection\Fixture\SecondClassLike;
+
+final class ReflectionParserTest extends TestCase
+{
+    private ReflectionParser $reflectionParser;
+
+    protected function setUp(): void
+    {
+        $this->reflectionParser = new ReflectionParser(new TypeAwareNodeFinder());
+    }
+
+    public function testParseMethodOfSecondClassLikeInFile(): void
+    {
+        $reflectionMethod = new ReflectionMethod(SecondClassLike::class, 'secondMethod');
+
+        $classMethod = $this->reflectionParser->parseMethodReflection($reflectionMethod);
+
+        $this->assertInstanceOf(ClassMethod::class, $classMethod);
+        $this->assertSame('secondMethod', $classMethod->name->toString());
+    }
+}


### PR DESCRIPTION
`ReflectionParser` cached one `ClassLike` per filename and took the first one in the file, so for a file with more than one class-like it returned the wrong class whatever was asked for.

`NoReferenceRule` then checks the parent method on that wrong class, so it reports or stays silent depending on declaration order.

Fix looks up the class-like by name. Test added first — it fails without the change.
